### PR TITLE
Update repo-stats.groovy

### DIFF
--- a/stats/repo-stats.groovy
+++ b/stats/repo-stats.groovy
@@ -44,7 +44,7 @@ executions {
                         [
                                 repoPath: path,
                                 count: repositories.getArtifactsCount(repoPath),
-                                size: repositories.getArtifactsSize(repoPath)
+                                size: repositories.getArtifactsSize(repoPath) +" bytes"
                         ]
                     } else {
                         log.warn("The path $path does not exist")


### PR DESCRIPTION
changed the getArtifactsSize method to reflect that the output is in bytes
