### PR TITLE
Report number of bytes found or deleted by the artifactoryCleanup script

### DIFF
--- a/cleanup/artifactCleanup/README.md
+++ b/cleanup/artifactCleanup/README.md
@@ -23,4 +23,4 @@ Executing
 
 To execute the plugin:
 
-`curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/cleanup?params=months=1|repos=libs-release-local|dryRun"`
+`curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/cleanup?params=months=1|repos=libs-release-local|dryRun=true"`

--- a/cleanup/artifactCleanup/artifactCleanup.groovy
+++ b/cleanup/artifactCleanup/artifactCleanup.groovy
@@ -36,10 +36,12 @@ private def artifactCleanup(int months, String[] repos, log, dryRun = false) {
 
     def monthsUntil = Calendar.getInstance()
     monthsUntil.add(Calendar.MONTH, -months)
-
+    
+    long bytesFound = 0;
     def artifactsCleanedUp =
         searches.artifactsNotDownloadedSince(monthsUntil, monthsUntil, repos).
         each {
+            bytesFound += repositories.getItemInfo(it)?.getSize() 
             if (dryRun) {
                 log.info "Found $it";
             } else {
@@ -49,8 +51,8 @@ private def artifactCleanup(int months, String[] repos, log, dryRun = false) {
         }
 
     if (dryRun) {
-        log.info "Dry run - nothing deleted. found $artifactsCleanedUp.size artifacts"
+        log.info "Dry run - nothing deleted. found $artifactsCleanedUp.size artifacts consuming $bytesFound bytes"
     } else {
-        log.info "Finished cleanup, deleted $artifactsCleanedUp.size artifacts"
+        log.info "Finished cleanup, deleted $artifactsCleanedUp.size artifacts that took up $bytesFound bytes"
     }
 }

--- a/cleanup/artifactCleanup/artifactCleanup.groovy
+++ b/cleanup/artifactCleanup/artifactCleanup.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 //curl command example for running this plugin. 
-//curl -i -uadmin:password -X POST "http://localhost:8081/artifactory/api/plugins/execute/cleanup?params=months=1|repos=libs-release-local|log|dryRun"
+//curl -i -uadmin:password -X POST "http://localhost:8081/artifactory/api/plugins/execute/cleanup?params=months=1|repos=libs-release-local|dryRun=true"
 executions {
     cleanup() { params ->
         def months = params['months'] ? params['months'][0] as int: 6


### PR DESCRIPTION
A minor tweak to have it report how many bytes were found. 

Also adjust the documentation to make it reliably hit the dry-run process (the previous example didn't actually seem to invoke the dry-run like it seemed it would and would actually delete things if dryRun=true wasn't passed in)