### PR TITLE
Added a storage quotaWarn plugin

### DIFF
--- a/storage/quotaWarn/QuotaWarnTest.groovy
+++ b/storage/quotaWarn/QuotaWarnTest.groovy
@@ -1,0 +1,38 @@
+import com.icegreen.greenmail.util.GreenMail
+import com.icegreen.greenmail.util.ServerSetup
+
+import javax.mail.internet.MimeMessage
+
+import static org.jfrog.artifactory.client.ArtifactoryClient.create
+
+import groovy.json.JsonSlurper
+import org.jfrog.artifactory.client.Artifactory
+
+import spock.lang.Specification
+
+/**
+ * Testing sending email when storage quota is reached.
+ * This test needs GreenMail in the classpath.
+ */
+class QuotaWarnTest extends Specification {
+    def 'test log sending quota warn emails'() {
+        setup:
+        Artifactory artifactory = create("http://localhost:8088/artifactory", "admin", "password")
+        ServerSetup setup = new ServerSetup(3025, "localhost", "smtp");
+        GreenMail greenMail = new GreenMail(setup)
+        greenMail.start()
+        // TODO : configure artifactory with the right quota and smtp server localhost:3025
+
+        when:
+        greenMail.waitForIncomingEmail(15000, 1)
+
+        then:
+        def messages = greenMail.getReceivedMessages()
+        println "messages : ${messages[0].subject}"
+        MimeMessage message = messages.find { MimeMessage message -> message.subject.contains('[WARN] ARTIFACTORY STORAGE QUOTA') }
+        assert message
+
+        cleanup:
+        greenMail.stop()
+    }
+}

--- a/storage/quotaWarn/QuotaWarnTest.groovy
+++ b/storage/quotaWarn/QuotaWarnTest.groovy
@@ -1,6 +1,8 @@
 import com.icegreen.greenmail.util.GreenMail
 import com.icegreen.greenmail.util.ServerSetup
 
+import javax.mail.Address
+import javax.mail.internet.InternetAddress
 import javax.mail.internet.MimeMessage
 
 import static org.jfrog.artifactory.client.ArtifactoryClient.create
@@ -15,24 +17,89 @@ import spock.lang.Specification
  * This test needs GreenMail in the classpath.
  */
 class QuotaWarnTest extends Specification {
+
     def 'test log sending quota warn emails'() {
         setup:
         Artifactory artifactory = create("http://localhost:8088/artifactory", "admin", "password")
         ServerSetup setup = new ServerSetup(3025, "localhost", "smtp");
         GreenMail greenMail = new GreenMail(setup)
         greenMail.start()
-        // TODO : configure artifactory with the right quota and smtp server localhost:3025
+        // TODO : configure artifactory with the right quota and smtp server localhost:3025 and an admin email of admin@test.local
 
         when:
         greenMail.waitForIncomingEmail(15000, 1)
 
         then:
         def messages = greenMail.getReceivedMessages()
-        println "messages : ${messages[0].subject}"
         MimeMessage message = messages.find { MimeMessage message -> message.subject.contains('[WARN] ARTIFACTORY STORAGE QUOTA') }
         assert message
+        assert message.allRecipients.each { InternetAddress addr -> assert addr.address == 'admin@test.local' }
 
         cleanup:
         greenMail.stop()
     }
+
+    def 'test sending mail limit strategy'() {
+        setup:
+        def sendingMailStrategy = new LimitAlertEmailsStrategy(maxNumberOfSuccessiveEmails: 10)
+
+        when: 'sending 10 mails'
+        10.times { assert sendingMailStrategy.shouldSendMail() }
+
+        then: 'the next time that shouldn \'t send mail'
+        10.times { assert !sendingMailStrategy.shouldSendMail() }
+    }
+
+    def 'test send mail limit strategy reset'() {
+        setup:
+        def sendingMailStrategy = new LimitAlertEmailsStrategy(maxNumberOfSuccessiveEmails: 10)
+
+        when: 'sending 10 mails'
+        10.times { assert sendingMailStrategy.shouldSendMail() }
+
+        then: 'next time we shouldn\'t send mail'
+        assert !sendingMailStrategy.shouldSendMail()
+
+        when: 'resetting'
+        sendingMailStrategy.reset()
+
+        then: 'it should send again the next 10 mails'
+        10.times { assert sendingMailStrategy.shouldSendMail() }
+
+        then: 'it shouldn\'t send the next emails'
+        assert !sendingMailStrategy.shouldSendMail()
+        assert !sendingMailStrategy.shouldSendMail()
+    }
+
+    def 'test send mail rate strategy'() {
+        setup:
+        def sendingMailStrategy = new SendAlertEmailsAtSomeRateStrategy(alertEmailRate: 10)
+
+        when: 'sending 1 mail'
+        assert sendingMailStrategy.shouldSendMail()
+
+        then: 'next 9 shouldn\'t send mails'
+        9.times { assert !sendingMailStrategy.shouldSendMail() }
+
+        then: 'next 1 should send mail'
+        assert sendingMailStrategy.shouldSendMail()
+    }
+
+    def 'test send mail rate strategy reset'() {
+        setup:
+        def sendingMailStrategy = new SendAlertEmailsAtSomeRateStrategy(alertEmailRate: 10)
+
+        when: 'sending 1 mail'
+        sendingMailStrategy.shouldSendMail()
+
+        then: 'next 5 shouldn\'t send mails'
+        5.times { assert !sendingMailStrategy.shouldSendMail() }
+
+        then: 'reset'
+        sendingMailStrategy.reset()
+
+        then: 'next 1 should send mail'
+        assert sendingMailStrategy.shouldSendMail()
+    }
+
 }

--- a/storage/quotaWarn/README.md
+++ b/storage/quotaWarn/README.md
@@ -1,0 +1,49 @@
+Artifactory Storage Quota Warning User Plugin
+=============================================
+
+This plugin is used to send email notifications when the storage quota warning / limit is reached.
+This is configured in the Artifactory UI at Admin > Advanced > Maintenance > Storage Quota.
+
+Installation
+------------
+
+To install this plugin:
+
+1. Place this script under the master Artifactory server
+   `${ARTIFACTORY_HOME}/etc/plugins`.
+2. Verify in the ${ARTIFACTORY_HOME}/logs/artifactory.log that the plugin loaded
+   correctly.
+
+Features
+--------
+
+- Send email notification to all admin users when the storage quota warning or the storage quota limit are reached.
+
+The email subject is :
+- `[Artifactory] [WARN] ARTIFACTORY STORAGE QUOTA` in case of a storage space warning or
+- `[Artifactory] [ERROR] ARTIFACTORY STORAGE QUOTA` in case of reaching the storage limit.
+
+The email content is the exact same message shown in the UI, for example :
+
+`Datastore disk space is too high: Max limit: 30%, Used: 32%, Total: 464.78 GB, Used: 149.21 GB, Available: 315.58 GB`
+
+### Execution ###
+This plugin is a scheduled task, fired every 10s by default.
+You can change this at the begining of the quotaWarn.groovy :
+`executionInterval = 10_000`
+
+### Limit the number of sent emails ###
+You can use one of the two provided strategies for limiting the number of sent notifications :
+
+-  Send only 10 sucessive emails (default) and then stop
+```JAVA
+EmailNotificationsStrategy sendingMailStrategy ` = new LimitAlertEmailsStrategy(maxNumberOfSuccessiveEmails: 10)
+```
+- Send one email every 10 alerts until the alert is over
+```JAVA
+EmailNotificationsStrategy sendingMailStrategy = new SendAlertEmailsAtSomeRateStrategy(alertEmailRate: 10)
+```
+
+
+
+

--- a/storage/quotaWarn/quotaWarn.groovy
+++ b/storage/quotaWarn/quotaWarn.groovy
@@ -34,9 +34,9 @@ def quotaCheck() {
     StorageService storageService = ContextHelper.get().beanForType(StorageService)
     MailService mailService = ContextHelper.get().beanForType(MailService)
     def storageQuotaInfo = storageService.getStorageQuotaInfo(0)
-    if (storageQuotaInfo.isLimitReached()) {
+    if (storageQuotaInfo?.isLimitReached()) {
         trySendMail(mailService, "[ERROR] ARTIFACTORY STORAGE QUOTA", storageQuotaInfo.getErrorMessage())
-    } else if (storageQuotaInfo.isWarningLimitReached()) {
+    } else if (storageQuotaInfo?.isWarningLimitReached()) {
         trySendMail(mailService, "[WARN] ARTIFACTORY STORAGE QUOTA", storageQuotaInfo.getWarningMessage())
     } else {
         sendingMailStrategy.reset()

--- a/storage/quotaWarn/quotaWarn.groovy
+++ b/storage/quotaWarn/quotaWarn.groovy
@@ -1,14 +1,20 @@
 import groovy.transform.Field
 import org.artifactory.api.context.ContextHelper
 import org.artifactory.api.mail.MailService
+import org.artifactory.api.security.UserGroupService
+import org.artifactory.security.UserInfo
 import org.artifactory.storage.StorageService
 import org.artifactory.util.EmailException
 
 
+/**
+ * Interval between storage checks (in ms)
+ */
 @Field
-def adminEmailAddress = 'admin@test.local'
+def executionInterval = 10_000
 @Field
-def executionInterval = 10000
+//EmailNotificationsStrategy sendingMailStrategy = new SendAlertEmailsAtSomeRateStrategy(alertEmailRate: 10)
+EmailNotificationsStrategy sendingMailStrategy = new LimitAlertEmailsStrategy(maxNumberOfSuccessiveEmails: 10)
 
 jobs {
     scheduledQuotaCheck(delay: 100, interval: executionInterval) {
@@ -21,7 +27,7 @@ jobs {
  * Checks every <code>executionInterval</code> if the storage space limit or storage space warning is reached.
  * This is configured in the UI at Admin > Advanced > Maintenance > Storage Quota.
  *
- * If the limit or warning is reached, a simple email with details is sent to <code>adminEmailAddress</code>
+ * If the limit or warning is reached, a simple email with details is sent to all admins.
  *
  */
 def quotaCheck() {
@@ -32,14 +38,79 @@ def quotaCheck() {
         trySendMail(mailService, "[ERROR] ARTIFACTORY STORAGE QUOTA", storageQuotaInfo.getErrorMessage())
     } else if (storageQuotaInfo.isWarningLimitReached()) {
         trySendMail(mailService, "[WARN] ARTIFACTORY STORAGE QUOTA", storageQuotaInfo.getWarningMessage())
+    } else {
+        sendingMailStrategy.reset()
     }
 }
 
 def trySendMail(def mailService, String subj, String message) {
     try {
-        mailService.sendMail([adminEmailAddress] as String[], subj, message)
-        log.warn("Quota mail notification sent to admin")
+        if (sendingMailStrategy.shouldSendMail()) {
+            def adminEmails = findAdminEmails() as String[]
+            mailService.sendMail(adminEmails, subj, message)
+            log.warn("Quota mail notification sent to admin")
+        }
     } catch (EmailException e) {
         log.error("Error while sending storage quota mail message.", e)
     }
+}
+
+List findAdminEmails() {
+    UserGroupService userGroupService = ContextHelper.get().beanForType(UserGroupService)
+    userGroupService.getAllUsers(true).findAll { UserInfo userInfo -> userInfo.isAdmin() && userInfo.email }.collect { it.email }
+}
+
+interface EmailNotificationsStrategy {
+    boolean shouldSendMail()
+    void reset()
+}
+
+/**
+ * Send only N successive alert emails and then stop. It will resend email once
+ * the reset method will be called, for example when there's no more storage alert.
+ */
+class LimitAlertEmailsStrategy implements EmailNotificationsStrategy {
+
+    private int currentNumberOfSuccessiveSentEmails
+    int maxNumberOfSuccessiveEmails
+
+    boolean shouldSendMail() {
+        boolean shouldSendMail = false
+        if (currentNumberOfSuccessiveSentEmails < maxNumberOfSuccessiveEmails) {
+            shouldSendMail = true
+            currentNumberOfSuccessiveSentEmails++
+        }
+        return shouldSendMail
+    }
+
+    void reset() {
+        currentNumberOfSuccessiveSentEmails = 0
+    }
+
+}
+
+/**
+ * Send one email every <code>alertEmailRate</code> alerts.
+ */
+class SendAlertEmailsAtSomeRateStrategy implements EmailNotificationsStrategy {
+
+    private int currentNumberOfAlerts
+
+    int alertEmailRate = 10
+
+    boolean shouldSendMail() {
+        boolean shouldSendMail = false
+        if (currentNumberOfAlerts == 0) {
+            shouldSendMail = true
+        } else if (currentNumberOfAlerts % alertEmailRate == 0) {
+            shouldSendMail = true
+        }
+        currentNumberOfAlerts++
+        return shouldSendMail
+    }
+    void reset() {
+        currentNumberOfAlerts = 0
+    }
+
+
 }

--- a/storage/quotaWarn/quotaWarn.groovy
+++ b/storage/quotaWarn/quotaWarn.groovy
@@ -1,0 +1,45 @@
+import groovy.transform.Field
+import org.artifactory.api.context.ContextHelper
+import org.artifactory.api.mail.MailService
+import org.artifactory.storage.StorageService
+import org.artifactory.util.EmailException
+
+
+@Field
+def adminEmailAddress = 'admin@test.local'
+@Field
+def executionInterval = 10000
+
+jobs {
+    scheduledQuotaCheck(delay: 100, interval: executionInterval) {
+        quotaCheck()
+    }
+}
+
+/**
+ *
+ * Checks every <code>executionInterval</code> if the storage space limit or storage space warning is reached.
+ * This is configured in the UI at Admin > Advanced > Maintenance > Storage Quota.
+ *
+ * If the limit or warning is reached, a simple email with details is sent to <code>adminEmailAddress</code>
+ *
+ */
+def quotaCheck() {
+    StorageService storageService = ContextHelper.get().beanForType(StorageService)
+    MailService mailService = ContextHelper.get().beanForType(MailService)
+    def storageQuotaInfo = storageService.getStorageQuotaInfo(0)
+    if (storageQuotaInfo.isLimitReached()) {
+        trySendMail(mailService, "[ERROR] ARTIFACTORY STORAGE QUOTA", storageQuotaInfo.getErrorMessage())
+    } else if (storageQuotaInfo.isWarningLimitReached()) {
+        trySendMail(mailService, "[WARN] ARTIFACTORY STORAGE QUOTA", storageQuotaInfo.getWarningMessage())
+    }
+}
+
+def trySendMail(def mailService, String subj, String message) {
+    try {
+        mailService.sendMail([adminEmailAddress] as String[], subj, message)
+        log.warn("Quota mail notification sent to admin")
+    } catch (EmailException e) {
+        log.error("Error while sending storage quota mail message.", e)
+    }
+}


### PR DESCRIPTION
Job to check if the storage space limit or storage space warning is reached.
This is configured in the UI at Admin > Advanced > Maintenance > Storage Quota.
If the limit or warning is reached, a simple email with details is sent to an email address.