### PR TITLE
Proxies plugin update: use string instead of list for redirectedToHost…

### DIFF
--- a/config/proxiesConfig/ProxiesConfigTest.groovy
+++ b/config/proxiesConfig/ProxiesConfigTest.groovy
@@ -28,7 +28,7 @@ class ProxiesConfigTest extends Specification {
             username: null, password: null,
             ntHost: null, domain: null,
             defaultProxy: false,
-            redirectedToHosts: ['rehost']]
+            redirectedToHosts: 'rehost']
         conn = new URL("$baseurl/addProxy").openConnection()
         conn.doOutput = true
         conn.setRequestProperty('Authorization', auth)

--- a/config/proxiesConfig/README.md
+++ b/config/proxiesConfig/README.md
@@ -34,7 +34,7 @@ returned JSON string has the following fields:
 - `ntHost`: The NTLM hostname of this machine.
 - `domain`: The domain/realm name.
 - `defaultProxy`: Whether this proxy is the default.
-- `redirectedToHosts`: An optional list of hosts the proxy might redirect to.
+- `redirectedToHosts`: An optional list of host names (separated by newline or comma) to which the proxy may redirect requests. The credentials of the proxy are reused by requests redirected to any of these hosts.
 
 For example:
 
@@ -49,10 +49,7 @@ $ curl -u admin:password 'http://localhost:8081/artifactory/api/plugins/execute/
     "ntHost": null,
     "domain": null,
     "defaultProxy": false,
-    "redirectedToHosts": [
-        "host1",
-        "host2"
-    ]
+    "redirectedToHosts": "host1,host2"
 }
 ```
 
@@ -87,7 +84,7 @@ $ curl -u admin:password -X POST -H 'Content-Type: application/json' -d '{
 > "ntHost": null,
 > "domain": null,
 > "defaultProxy": false,
-> "redirectedToHosts": ["host1", "host2"]
+> "redirectedToHosts": "host1,host2"
 > }' 'http://localhost:8081/artifactory/api/plugins/execute/addProxy'
 ```
 

--- a/config/proxiesConfig/proxiesConfig.groovy
+++ b/config/proxiesConfig/proxiesConfig.groovy
@@ -45,8 +45,8 @@ def propList = ['key': [
         Boolean.class, 'boolean',
         { c, v -> c.defaultProxy = v ?: false }
     ], 'redirectedToHosts': [
-        Iterable.class, 'list',
-        { c, v -> c.redirectedToHosts = v?.join(',') ?: '' }]]
+        CharSequence.class, 'string',
+        { c, v -> c.redirectedToHosts = v ?: null }]]
 
 executions {
     getProxiesList(version: '1.0', httpMethod: 'GET') { params ->
@@ -79,7 +79,7 @@ executions {
             ntHost: proxy.ntHost ?: null,
             domain: proxy.domain ?: null,
             defaultProxy: proxy.defaultProxy ?: false,
-            redirectedToHosts: proxy.redirectedToHostsList]
+            redirectedToHosts: proxy.redirectedToHosts]
         message = new JsonBuilder(json).toPrettyString()
         status = 200
     }


### PR DESCRIPTION
To be consistent with REST API(for example, replication endpoint returns redirectedToHost field as String)