### PR TITLE
Update synchronizeLdapGroups.groovy

### DIFF
--- a/security/synchronizeLdapGroups/synchronizeLdapGroups.groovy
+++ b/security/synchronizeLdapGroups/synchronizeLdapGroups.groovy
@@ -24,7 +24,7 @@ import org.artifactory.security.groups.LdapGroupsSettings
  */
 
 realms {
-    myrealm([autoCreateUsers: false, realmPolicy: RealmPolicy.ADDITIVE]) {
+    myrealm([autoCreateUsers: false, realmPolicy: RealmPolicy.SUFFICIENT]) {
         authenticate { username, credentials ->
             def settings = new LdapGroupsSettings()
             // 'il-users' is an existing Ldap Group Setting Name in Artifactory


### PR DESCRIPTION
RealmPolicy has been modified to SUFFICIENT. Without it, it didn't let artifactory user to even login to Artifactory.