### PR TITLE
Use user context variable

### DIFF
--- a/security/synchronizeLdapGroups/synchronizeLdapGroups.groovy
+++ b/security/synchronizeLdapGroups/synchronizeLdapGroups.groovy
@@ -26,7 +26,7 @@ import org.artifactory.security.groups.LdapGroupsSettings
 realms {
     myrealm([autoCreateUsers: false, realmPolicy: RealmPolicy.ADDITIVE]) {
         authenticate { username, credentials ->
-            if (security.findUser(username).realm == 'internal') return false
+            if (user.realm == 'internal') return false
             def settings = new LdapGroupsSettings()
             // 'il-users' is an existing Ldap Group Setting Name in Artifactory
             // All the permissions given to the group will be inherited by the user
@@ -36,7 +36,7 @@ realms {
         }
 
         userExists { username ->
-            return security.findUser(username).realm != 'internal'
+            return user.realm != 'internal'
         }
     }
 }


### PR DESCRIPTION
security.findUser(username) is not authorized for a non admin user so it is better to use directly the context variable `user`