### PR TITLE
pluginsConfig fixed

### DIFF
--- a/config/pluginsConfig/PluginsConfigTest.groovy
+++ b/config/pluginsConfig/PluginsConfigTest.groovy
@@ -24,7 +24,7 @@ class PluginConfigTest extends Specification {
   def 'download plugin test'(){
     setup:
     def baseurl = 'http://localhost:8088/artifactory/api/plugins/execute'
-    def params = '?params=name=pluginsConfig'
+    def params = '?params=name=pluginsConfig.groovy'
     def auth = "Basic ${'admin:password'.bytes.encodeBase64()}"
     def conn = null
 

--- a/config/pluginsConfig/pluginsConfig.groovy
+++ b/config/pluginsConfig/pluginsConfig.groovy
@@ -15,6 +15,7 @@
  */
 
 import groovy.io.FileType
+import groovy.json.JsonBuilder
 import org.artifactory.api.repo.exception.ItemNotFoundRuntimeException
 
 executions {
@@ -35,7 +36,7 @@ executions {
       message = "There are no user plugins installed in this Artifactory instance"
       status 204
     } else {
-      message = list
+      message = new JsonBuilder(list).toPrettyString()
       status = 200
     }
   }
@@ -44,7 +45,7 @@ executions {
   downloadPlugin(httpMethod: 'GET') { params->
     def pluginName = params?.('name')?.get(0) as String
 
-    File pluginFile = new File("${artHome}/plugins/${pluginName}.groovy")
+    File pluginFile = new File("${artHome}/plugins/${pluginName}")
     if (!pluginName || !pluginFile.exists()) {
       message = "Error: ${pluginName} was not found"
       status = 400
@@ -54,5 +55,3 @@ executions {
     }
   }
 }
-
-


### PR DESCRIPTION
- Fixed  **listPlugins**  Return `[ "plugin1.groovy",  "plugin2.groovy"]` instead of `[ plugin1.groovy,  plugin2.groovy]`
- Fixed  **downloadPlugin** `pluginName` should contain full file name see **listPlugins**