### PR TITLE
Change readmes to reflect changes in pipe character usage on curl commands

### DIFF
--- a/archive/archiveOldArtifacts/README.md
+++ b/archive/archiveOldArtifacts/README.md
@@ -93,23 +93,23 @@ Sample REST Calls
   `curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/archive\_old_artifacts?params=ageDays=30"`
 - Archive any artifact that is 30 days old and has the following properties set:
 
-  `curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/archive\_old_artifacts?params=ageDays=30|includedPropertySet=deleteme:true;junk:true"`
+  `curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/archive\_old_artifacts?params=ageDays=30;includedPropertySet=deleteme:true;junk:true"`
 - Archive any artifact that has not been downloaded in 60 days, excluding those
   with a certain property set:
 
-  `curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/archive\_old_artifacts?params=lastDownloadedDays=60|excludedPropertySet=keeper:true"`
+  `curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/archive\_old_artifacts?params=lastDownloadedDays=60;excludedPropertySet=keeper:true"`
 - Archive only `*.tgz` files that are 30 days old and have not been downloaded
   in 15 days:
 
-  `curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/archive\_old_artifacts?params=filePattern=*.tgz|ageDays=30|lastDownloadedDays=15"`
+  `curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/archive\_old_artifacts?params=filePattern=*.tgz;ageDays=30;lastDownloadedDays=15"`
 - Archive any `*.tgz` artifact that is 30 days old and is tagged with
   `artifact.delete`:
 
-  `curl -X POST -v -u <admin_user>:<admin_password> "http://localhost:8080/artifactory/api/plugins/execute/archive_old_artifacts?params=filePattern=*.tgz|ageDays=30|includePropertySet=artifact.delete"`
+  `curl -X POST -v -u <admin_user>:<admin_password> "http://localhost:8080/artifactory/api/plugins/execute/archive_old_artifacts?params=filePattern=*.tgz;ageDays=30;includePropertySet=artifact.delete"`
 - Archive any `*.tgz` artifact that is 15 days old and is tagged with
   `artifact.delete=true`:
 
-  `curl -X POST -v -u <admin_user>:<admin_password> "http://localhost:8080/artifactory/api/plugins/execute/archive_old_artifacts?params=filePattern=*.tgz|ageDays=15|includePropertySet=artifact.delete:true"`
+  `curl -X POST -v -u <admin_user>:<admin_password> "http://localhost:8080/artifactory/api/plugins/execute/archive_old_artifacts?params=filePattern=*.tgz;ageDays=15;includePropertySet=artifact.delete:true"`
 
 Archive Process
 ---------------

--- a/build/buildReplication/README.md
+++ b/build/buildReplication/README.md
@@ -33,7 +33,7 @@ Execution
 	```
 	- You can pass all the parameters for the plugin in the REST call:
 	```
-	curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/buildReplication?params=master=http://localhost:8080/artifactory|masterUser=admin|masterPassword=password|slave=http://localhost:8081/artifactory|slaveUser=admin|slavePassword=password|deleteDifferentBuild=false"
+	curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/buildReplication?params=master=http://localhost:8080/artifactory;masterUser=admin;masterPassword=password;slave=http://localhost:8081/artifactory;slaveUser=admin;slavePassword=password;deleteDifferentBuild=false"
 	```
 
 Logic
@@ -53,5 +53,5 @@ The script can get 7 params:
 	- User name and password\security key to the replicated server
 	- True\false flag which delete builds that don't exist at the main server and exist at the replicated server (not mandatory)
 	```
-	curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/buildReplication?params=master=masterArtifactory|masterUser=masterArtifactoryUser|masterPassword=masterPassword|slave=slaveArtifactory|slaveUser=slaveUser|slavePassword=slavePassword|deleteDifferentBuild=true/false"
+	curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/buildReplication?params=master=masterArtifactory;masterUser=masterArtifactoryUser;masterPassword=masterPassword;slave=slaveArtifactory;slaveUser=slaveUser;slavePassword=slavePassword;deleteDifferentBuild=true/false"
 	```

--- a/build/mavenBuildDeps/buildArtifactsAGVList/README.md
+++ b/build/mavenBuildDeps/buildArtifactsAGVList/README.md
@@ -16,7 +16,7 @@ buildStartTime - StartTime of build to promote (optional - in case you have mutl
 For example:
 
 ```
-curl -H "Content-Type:application/json" -X POST  -uadmin:password "http://localhost:8080/artifactory/api/plugins/execute/MavenDep?params=buildName=Generic|buildNumber=28"
+curl -H "Content-Type:application/json" -X POST  -uadmin:password "http://localhost:8080/artifactory/api/plugins/execute/MavenDep?params=buildName=Generic;buildNumber=28"
 ```
 
 

--- a/build/promoteWithDeps/README.md
+++ b/build/promoteWithDeps/README.md
@@ -37,7 +37,7 @@ ReqBody
 For example:
 
 ```
-curl -H "Content-Type:application/json" -X POST -d '{"status": "Staged","comment": "Tested on all target platforms.", "ciUser": "admin","dryRun": false,"targetRepo": { "maven-example": "master-repo","dep-build1": "dep-repo1", "dep-build2": "dep-repo1", "dep-build3": "dep-repo1" }, "copy": true, "artifacts": true, "dependencies": false, "failFast": true }' -uadmin:password "http://localhost:8080/artifactory/api/plugins/execute/promoteWithDeps?params=buildName=Generic|buildNumber=28"
+curl -H "Content-Type:application/json" -X POST -d '{"status": "Staged","comment": "Tested on all target platforms.", "ciUser": "admin","dryRun": false,"targetRepo": { "maven-example": "master-repo","dep-build1": "dep-repo1", "dep-build2": "dep-repo1", "dep-build3": "dep-repo1" }, "copy": true, "artifacts": true, "dependencies": false, "failFast": true }' -uadmin:password "http://localhost:8080/artifactory/api/plugins/execute/promoteWithDeps?params=buildName=Generic;buildNumber=28"
 ```
 
 ReqBody:

--- a/build/promotion/README.md
+++ b/build/promotion/README.md
@@ -28,4 +28,4 @@ Parameters
 
 For example:
 
-`curl -X POST -uadmin:password http://localhost:8080/artifactory/api/plugins/build/promote/snapshotToRelease/gradle-multi-example/1?params=snapExp=d%7B14%7D|targetRepository=gradle-release-local`
+`curl -X POST -uadmin:password http://localhost:8080/artifactory/api/plugins/build/promote/snapshotToRelease/gradle-multi-example/1?params=snapExp=d%7B14%7D;targetRepository=gradle-release-local`

--- a/build/taggingPromotion/README.md
+++ b/build/taggingPromotion/README.md
@@ -30,4 +30,4 @@ To execute this plugin use the [Execute Build Promotion](https://www.jfrog.com/c
 
 Example:
 
-`curl -X POST -v -u user:password "http://localhost:8080/artifactory/api/plugins/build/promote/cloudPromote/<BUILD_NAME>/<BUILD_NUMBER>?params=targetRepository=<TARGET_REPO>|prod=true"`
+`curl -X POST -v -u user:password "http://localhost:8080/artifactory/api/plugins/build/promote/cloudPromote/<BUILD_NAME>/<BUILD_NUMBER>?params=targetRepository=<TARGET_REPO>;prod=true"`

--- a/cleanup/artifactCleanup/README.md
+++ b/cleanup/artifactCleanup/README.md
@@ -34,7 +34,7 @@ Executing
 
 To execute the plugin:
 
-`curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/cleanup?params=months=1|repos=libs-release-local|dryRun|paceTimeMS=2000"`
+`curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/cleanup?params=months=1;repos=libs-release-local;dryRun;paceTimeMS=2000"`
 
 
 
@@ -56,4 +56,4 @@ The plugin have 4 control options:
 `curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/cleanupCtl?params=command=resume"`
 - `adjustPaceTimeMS`: Modify the running delay factor by increasing/decreasing the delay value. Example:
 
-`curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/cleanupCtl?params=command=adjustPaceTimeMS|value=-1000"`
+`curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/cleanupCtl?params=command=adjustPaceTimeMS;value=-1000"`

--- a/cleanup/buildCleanup/README.md
+++ b/cleanup/buildCleanup/README.md
@@ -21,4 +21,4 @@ Executing
 
 To execute the plugin:
 
-`curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/cleanBuilds?params=days=50|dryRun"`
+`curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/cleanBuilds?params=days=50;dryRun"`

--- a/filestore/exposeFilestore/README.md
+++ b/filestore/exposeFilestore/README.md
@@ -17,4 +17,4 @@ This plugin takes two parameters:
 
 For example:
 
-`curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/exposeRepository?params=repo=repoKey|dest=destFolder"`
+`curl -X POST -v -u admin:password "http://localhost:8080/artifactory/api/plugins/execute/exposeRepository?params=repo=repoKey;dest=destFolder"`

--- a/ha/requestRouting/README.md
+++ b/ha/requestRouting/README.md
@@ -31,7 +31,7 @@ For example:
 
 ```
 $ curl -u admin:password \
- 'http://localhost:8081/artifactory/api/plugins/execute/routedGet?params=serverId=ha_artifactory_1_1|apiEndpoint=api/plugins/execute/haClusterDump'
+ 'http://localhost:8081/artifactory/api/plugins/execute/routedGet?params=serverId=ha_artifactory_1_1;apiEndpoint=api/plugins/execute/haClusterDump'
 ```
 
 

--- a/metadata/getPypiMetadata/README.md
+++ b/metadata/getPypiMetadata/README.md
@@ -11,4 +11,4 @@ metadata will be extracted.
 
 Example execution:
 
-`curl -X POST -v -u admin:password "http://localhost:8081/artifactory/api/plugins/execute/getPypiMetadata?params=repoPath=/3.3/s/six/six-1.9.0-py2.py3-none-any.whl|repoKey=pypi-remote-cache"`
+`curl -X POST -v -u admin:password "http://localhost:8081/artifactory/api/plugins/execute/getPypiMetadata?params=repoPath=/3.3/s/six/six-1.9.0-py2.py3-none-any.whl;repoKey=pypi-remote-cache"`

--- a/nexusPush/README.md
+++ b/nexusPush/README.md
@@ -25,7 +25,7 @@ example, oss.sonatype.org).
      ```
 
 2. Execute a POST request authenticated with an Artifactory admin user with the
-   following parameters separated by pipes (`|`):
+   following parameters separated by pipes (`;`):
    - `stagingProfile`: The name of the profile file (without the 'properties'
      extension). E.g. for a profile saved in
      `${ARTIFACTORY_HOME}/etc/plugins/nexusPush.properties`, the parameter will
@@ -39,12 +39,12 @@ example, oss.sonatype.org).
        are allowed, where `property` is the full name of the Artifactory
        property (including the set name). All artifacts with all of these
        properties and values will be pushed. E.g.
-       `build.name=spaceship-new-rel|build.number=143`.
+       `build.name=spaceship-new-rel;build.number=143`.
    - `close`: whether or not the staging repository should be closed. Defaults
      to `true`.
 
 3. Examples of the request using CURL:
    - Query by directory, upload only (without closing):
-     `curl -X POST -v -u admin:password "http://localhost:8090/artifactory/api/plugins/execute/nexusPush?params=stagingProfile=nexusPush|close=false|dir=lib-release-local%2Forg%spacecrafts%2Fspaceship-new-rel%2F1.0"`
+     `curl -X POST -v -u admin:password "http://localhost:8090/artifactory/api/plugins/execute/nexusPush?params=stagingProfile=nexusPush;close=false;dir=lib-release-local%2Forg%spacecrafts%2Fspaceship-new-rel%2F1.0"`
    - Query by properties:
-     `curl -X POST -v -u admin:password "http://localhost:8090/artifactory/api/plugins/execute/nexusPush?params=stagingProfile=nexusPush|build.name=spaceship-new-rel|build.number=143"`
+     `curl -X POST -v -u admin:password "http://localhost:8090/artifactory/api/plugins/execute/nexusPush?params=stagingProfile=nexusPush;build.name=spaceship-new-rel;build.number=143"`


### PR DESCRIPTION
I believe since we switched Tomcat versions we can't use pipe character '|' on our curl commands anymore, so under Aaron's instructions I automated the process of changing them. I double checked to make sure only the right things were changed by my script, but only README.md files were changed.