### PR TITLE
Maven Snapshot Cleanup When Release feature

### DIFF
--- a/cleanup/mavenSnapshotCleanupWhenRelease/MavenSnapshotCleanupWhenReleaseTest.groovy
+++ b/cleanup/mavenSnapshotCleanupWhenRelease/MavenSnapshotCleanupWhenReleaseTest.groovy
@@ -1,0 +1,214 @@
+import static org.jfrog.artifactory.client.ArtifactoryClient.create
+
+import org.jfrog.artifactory.client.Artifactory
+import org.jfrog.artifactory.client.model.impl.SnapshotVersionBehaviorImpl
+import org.jfrog.artifactory.client.model.repository.settings.impl.MavenRepositorySettingsImpl
+
+import groovyx.net.http.HttpResponseException
+import spock.lang.Specification
+
+class MavenSnapshotCleanupWhenReleaseTest extends Specification {
+
+    def TEST_FOLDER = 'org/jfrog/test'
+    def TEST_NAME = 'test-snapshot-cleanup-when-release'
+    def TEST_REPO_RELEASES = 'maven-local-releases'
+    def TEST_REPO_SNAPSHOTS = 'maven-local-snaphots'
+
+    private void createClientAndMavenRepo(Artifactory artifactory, String repoName, boolean handleReleases, boolean handleSnapshots){
+        createClientAndMavenRepo(artifactory, repoName, handleReleases, handleSnapshots, false)
+    }
+
+    private void createClientAndMavenRepo(Artifactory artifactory, String repoName, boolean handleReleases, boolean handleSnapshots, boolean suppressPomConsistency){
+        def builder = artifactory.repositories().builders()
+        def repoSettings = new MavenRepositorySettingsImpl()
+        repoSettings.handleReleases = handleReleases
+        repoSettings.handleSnapshots = handleSnapshots
+        repoSettings.suppressPomConsistencyChecks = suppressPomConsistency
+        if (handleSnapshots){
+            repoSettings.snapshotVersionBehavior = SnapshotVersionBehaviorImpl.unique
+        }
+
+        def repository = builder.localRepositoryBuilder().key(repoName)
+            .repositorySettings(repoSettings).build()
+
+        artifactory.repositories().create(0, repository)
+    }
+
+
+    def 'Maven Snapshot Cleanup When Release promotion move same repo test'() {
+        setup:
+        def baseurl = 'http://localhost:8088/artifactory'
+        def artifactory = create(baseurl, 'admin', 'password')
+        createClientAndMavenRepo(artifactory, 'maven-local', true, true, true)
+
+        artifactory.plugins().execute('mavenSnapshotCleanupWhenReleaseConfig').
+            withParameter('action', 'reset').withParameter('repositories', '[["maven-local","maven-local"]]').sync()
+
+        when:
+        // Double upload to generate -2 snapshot
+        uploadMavenArtifact(artifactory, 'maven-local', '1.0.0-SNAPSHOT')
+        def snapName = uploadMavenArtifact(artifactory, 'maven-local', '1.0.0-SNAPSHOT')
+        artifactory.repository('maven-local').file(TEST_FOLDER + '/' + TEST_NAME + '/1.0.0-SNAPSHOT/' + snapName + '.jar').move('maven-local', TEST_FOLDER + '/' + TEST_NAME + '/1.0.0/'+TEST_NAME + '-1.0.0.jar')
+        artifactory.repository('maven-local').file(TEST_FOLDER + '/' + TEST_NAME + '/1.0.0-SNAPSHOT/' + snapName + '.pom').move('maven-local', TEST_FOLDER + '/' + TEST_NAME + '/1.0.0/'+TEST_NAME + '-1.0.0.pom')
+
+        artifactory.repository('maven-local').file(TEST_FOLDER + '/' + TEST_NAME + '/1.0.0-SNAPSHOT').info()
+
+        then:
+        thrown(HttpResponseException)
+
+        when:
+        def metaData = artifactory.repository('maven-local').download(TEST_FOLDER + '/' + TEST_NAME + '/maven-metadata.xml').doDownload().text
+        assert !metaData.contains('1.0.0-SNAPSHOT')
+        assert metaData.contains('1.0.0')
+
+        then:
+        notThrown(HttpResponseException)
+
+        cleanup:
+        artifactory.repository('maven-local').delete()
+    }
+
+    def 'Maven Snapshot Cleanup When Release promotion move two repo test'() {
+        setup:
+        def baseurl = 'http://localhost:8088/artifactory'
+        def artifactory = create(baseurl, 'admin', 'password')
+        createClientAndMavenRepo(artifactory, TEST_REPO_RELEASES, true, false, true)
+        createClientAndMavenRepo(artifactory, TEST_REPO_SNAPSHOTS, false, true)
+        artifactory.plugins().execute('mavenSnapshotCleanupWhenReleaseConfig').
+            withParameter('action', 'reset').withParameter('repositories', '[["'+TEST_REPO_RELEASES+'","'+TEST_REPO_SNAPSHOTS+'"]]').sync()
+
+        when:
+        def snapName = uploadMavenArtifact(artifactory, TEST_REPO_SNAPSHOTS, '1.0.0-SNAPSHOT')
+        artifactory.repository(TEST_REPO_SNAPSHOTS).file(TEST_FOLDER + '/' + TEST_NAME + '/1.0.0-SNAPSHOT/' + snapName + '.jar').move(TEST_REPO_RELEASES, TEST_FOLDER + '/' + TEST_NAME + '/1.0.0/'+TEST_NAME + '-1.0.0.jar')
+        artifactory.repository(TEST_REPO_SNAPSHOTS).file(TEST_FOLDER + '/' + TEST_NAME + '/1.0.0-SNAPSHOT/' + snapName + '.pom').move(TEST_REPO_RELEASES, TEST_FOLDER + '/' + TEST_NAME + '/1.0.0/'+TEST_NAME + '-1.0.0.pom')
+
+        artifactory.repository(TEST_REPO_SNAPSHOTS).file(TEST_FOLDER + '/' + TEST_NAME + '/1.0.0-SNAPSHOT').info()
+
+        then:
+        thrown(HttpResponseException)
+
+        when:
+        // Sometime metatData creation takes some time
+        sleep(3000)
+        def metaDataRelease = artifactory.repository(TEST_REPO_RELEASES).download(TEST_FOLDER + '/' + TEST_NAME + '/maven-metadata.xml').doDownload().text
+        assert metaDataRelease.contains('1.0.0')
+
+        then:
+        notThrown(HttpResponseException)
+
+        when:
+        artifactory.repository(TEST_REPO_SNAPSHOTS).download(TEST_FOLDER + '/' + TEST_NAME + '/maven-metadata.xml').doDownload().text
+
+        then:
+        thrown(HttpResponseException)
+
+        cleanup:
+        artifactory.repository(TEST_REPO_RELEASES).delete()
+        artifactory.repository(TEST_REPO_SNAPSHOTS).delete()
+    }
+
+    def 'Maven Snapshot Cleanup When Release disable test'() {
+        setup:
+        def baseurl = 'http://localhost:8088/artifactory'
+        def artifactory = create(baseurl, 'admin', 'password')
+        createClientAndMavenRepo(artifactory, TEST_REPO_RELEASES, true, false)
+        createClientAndMavenRepo(artifactory, TEST_REPO_SNAPSHOTS, false, true)
+        artifactory.plugins().execute('mavenSnapshotCleanupWhenReleaseConfig').withParameter('action', 'reset').sync()
+
+        when:
+        def snapName = uploadMavenArtifact(artifactory, TEST_REPO_SNAPSHOTS, '1.1.0-SNAPSHOT')
+        uploadMavenArtifact(artifactory, TEST_REPO_RELEASES, '1.1.0')
+        artifactory.repository(TEST_REPO_SNAPSHOTS).file(TEST_FOLDER + '/' + TEST_NAME + '/1.1.0-SNAPSHOT/' + snapName + '.pom').info()
+
+        then:
+        notThrown(HttpResponseException)
+
+        cleanup:
+        artifactory.repository(TEST_REPO_RELEASES).delete()
+        artifactory.repository(TEST_REPO_SNAPSHOTS).delete()
+    }
+
+    def 'Maven Snapshot Cleanup When Release same repo test'() {
+        setup:
+        def baseurl = 'http://localhost:8088/artifactory'
+        def artifactory = create(baseurl, 'admin', 'password')
+        createClientAndMavenRepo(artifactory, 'maven-local', true, true)
+
+        artifactory.plugins().execute('mavenSnapshotCleanupWhenReleaseConfig').
+            withParameter('action', 'reset').withParameter('repositories', '[["maven-local","maven-local"]]').sync()
+
+        def snapName = uploadMavenArtifact(artifactory, 'maven-local', '1.0.0-SNAPSHOT')
+        uploadMavenArtifact(artifactory, 'maven-local', '1.1.0-SNAPSHOT')
+
+        when:
+        uploadMavenArtifact(artifactory, 'maven-local', '1.1.0')
+        artifactory.repository('maven-local').file(TEST_FOLDER + '/' + TEST_NAME + '/1.1.0-SNAPSHOT').info()
+
+        then:
+        thrown(HttpResponseException)
+
+        when:
+        artifactory.repository('maven-local').file(TEST_FOLDER + '/' + TEST_NAME + '/1.0.0-SNAPSHOT').info()
+        artifactory.repository('maven-local').file(TEST_FOLDER + '/' + TEST_NAME + '/1.0.0-SNAPSHOT/' + snapName  + '.pom').info()
+        artifactory.repository('maven-local').file(TEST_FOLDER + '/' + TEST_NAME + '/1.0.0-SNAPSHOT/' + snapName  + '.jar').info()
+        def metaData = artifactory.repository('maven-local').download(TEST_FOLDER + '/' + TEST_NAME + '/maven-metadata.xml').doDownload().text
+        assert metaData.contains('1.0.0-SNAPSHOT')
+        assert !metaData.contains('1.1.0-SNAPSHOT')
+
+        then:
+        notThrown(HttpResponseException)
+
+        cleanup:
+        artifactory.repository('maven-local').delete()
+    }
+
+    def 'Maven Snapshot Cleanup When Release classic test'() {
+        setup:
+        def baseurl = 'http://localhost:8088/artifactory'
+        def artifactory = create(baseurl, 'admin', 'password')
+        createClientAndMavenRepo(artifactory, TEST_REPO_RELEASES, true, false)
+        createClientAndMavenRepo(artifactory, TEST_REPO_SNAPSHOTS, false, true)
+        artifactory.plugins().execute('mavenSnapshotCleanupWhenReleaseConfig').
+            withParameter('action', 'reset').withParameter('repositories', '[["'+TEST_REPO_RELEASES+'","'+TEST_REPO_SNAPSHOTS+'"]]').sync()
+
+        def snapName = uploadMavenArtifact(artifactory, TEST_REPO_SNAPSHOTS, '1.0.0-SNAPSHOT')
+        uploadMavenArtifact(artifactory, TEST_REPO_SNAPSHOTS, '1.1.0-SNAPSHOT')
+
+        when:
+        uploadMavenArtifact(artifactory, TEST_REPO_RELEASES, '1.1.0')
+        artifactory.repository(TEST_REPO_SNAPSHOTS).file(TEST_FOLDER + '/' + TEST_NAME + '/1.1.0-SNAPSHOT').info()
+
+        then:
+        thrown(HttpResponseException)
+
+        when:
+        artifactory.repository(TEST_REPO_SNAPSHOTS).file(TEST_FOLDER + '/' + TEST_NAME + '/1.0.0-SNAPSHOT').info()
+        artifactory.repository(TEST_REPO_SNAPSHOTS).file(TEST_FOLDER + '/' + TEST_NAME + '/1.0.0-SNAPSHOT/' + snapName + '.pom').info()
+        artifactory.repository(TEST_REPO_SNAPSHOTS).file(TEST_FOLDER + '/' + TEST_NAME + '/1.0.0-SNAPSHOT/' + snapName + '.jar').info()
+        def metaData = artifactory.repository(TEST_REPO_SNAPSHOTS).download(TEST_FOLDER + '/' + TEST_NAME + '/maven-metadata.xml').doDownload().text
+        assert metaData.contains('1.0.0-SNAPSHOT')
+        assert !metaData.contains('1.1.0-SNAPSHOT')
+
+        then:
+        notThrown(HttpResponseException)
+
+        cleanup:
+        artifactory.repository(TEST_REPO_RELEASES).delete()
+        artifactory.repository(TEST_REPO_SNAPSHOTS).delete()
+    }
+
+
+    // Return the file name without extention (could be modified when SNAPSHOT version due to Maven timestamp snapshot behavior)
+    private def uploadMavenArtifact(Artifactory artifactory, String repo, String version){
+        def pomContent = '<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"><modelVersion>4.0.0</modelVersion><groupId>' + TEST_FOLDER.replace('/', '.') + '</groupId><artifactId>' + TEST_NAME + '</artifactId><version>'+version+'</version><packaging>jar</packaging></project>'
+        def pom = new ByteArrayInputStream(pomContent.bytes)
+        def jar = new ByteArrayInputStream('fake jar'.bytes)
+
+        def artifactPathPrefix = TEST_FOLDER + '/' + TEST_NAME + '/' + version + '/' + TEST_NAME + '-' + version
+
+        artifactory.repository(repo).upload(artifactPathPrefix + '.jar', jar).doUpload()
+        org.jfrog.artifactory.client.model.File file = artifactory.repository(repo).upload(artifactPathPrefix + '.pom', pom).doUpload()
+
+        return file.getName() - '.pom'
+    }
+}

--- a/cleanup/mavenSnapshotCleanupWhenRelease/README.md
+++ b/cleanup/mavenSnapshotCleanupWhenRelease/README.md
@@ -1,0 +1,62 @@
+Artifactory Maven Snapshot Cleanup When Release
+=====================================
+
+This plugin deletes Maven SNAPSHOT artifacts when the release version is published.
+
+
+Features
+--------
+
+Consider the Maven snapshots repository `maven-local-lib-snapshots` populated like that:
+
+    org/jfrog/test/my-artifact/1.0.0-SNAPSHOT/my-artifact-1.0.0-20170101.080829-1.pom
+    org/jfrog/test/my-artifact/1.0.0-SNAPSHOT/my-artifact-1.0.0-20170101.080829-1.jar
+    org/jfrog/test/my-artifact/1.0.0-SNAPSHOT/my-artifact-1.0.0-20170101.080829-2.pom
+    org/jfrog/test/my-artifact/1.0.0-SNAPSHOT/my-artifact-1.0.0-20170101.080829-2.jar
+
+    org/jfrog/test/my-artifact/1.1.0-SNAPSHOT/my-artifact-1.1.0-20170202.080829-1.pom
+    org/jfrog/test/my-artifact/1.1.0-SNAPSHOT/my-artifact-1.1.0-20170202.080829-1.jar
+
+
+When the **pom file** of `my-artifact` version `1.0.0` is deployed into `maven-local-lib-releases` (Maven releases repository), the associated snapshot is deleted.
+
+e.g: folder `org/jfrog/test/my-artifact/1.0.0-SNAPSHOT/` of `maven-local-lib-snapshots` repository.
+
+Installation
+------------
+
+To install this plugin:
+
+* Place files `mavenSnapshotCleanupWhenRelease.groovy` and `mavenSnapshotCleanupWhenRelease.properties` under the master Artifactory server `${ARTIFACTORY_HOME}/etc/plugins`.
+
+* Configure the file `mavenSnapshotCleanupWhenRelease.properties` with the repositories couples *releases <-> snapshots*. In a couple, the first should be the *release* repository and the second the *snapshot* repository:
+```
+    repositories =  [ ["maven-local-lib-releases","maven-local-lib-snapshots"], ["maven-local-plugin-releases","maven-local-plugin-snapshots"] ]
+```
+ 
+* Configure the logger in `${ARTIFACTORY_HOME}/etc/logback.xml` with level wanted:
+
+```
+    <configuration ...>
+        ...
+        <logger name="mavenSnapshotCleanupWhenRelease">
+            <level value="info"/>
+        </logger>   
+    </configuration>
+```
+
+* Verify in the `${ARTIFACTORY_HOME}/logs/artifactory.log` that the plugin and configuration loaded correctly.
+
+Execution
+---------
+
+The plugin deletion process is called when an artifact (pom and associated files like a jar, ...) is deployed in a configured Maven release repository, precisely when POM file is deployed. 
+
+The plugin configuration could be updated dynamically, using `api/plugins/execute/mavenSnapshotCleanupWhenReleaseConfig` URL with `params`:
+
+- `repositories`: The list of couple like in `mavenSnapshotCleanupWhenRelease.properties`, but with braquet/quote/comma URL encoded
+- `action`: (Optional) `reset`current configuration before do the `add` (default action) 
+
+Example:
+
+    curl -i -uadmin:password -X POST "http://localhost:8081/artifactory/api/plugins/execute/mavenSnapshotCleanupWhenReleaseConfig?params=action=reset;repositories=%5B%5B%22maven-local-lib-releases%22%2C%22maven-local-lib-snapshots%22%5D%5D"

--- a/cleanup/mavenSnapshotCleanupWhenRelease/mavenSnapshotCleanupWhenRelease.groovy
+++ b/cleanup/mavenSnapshotCleanupWhenRelease/mavenSnapshotCleanupWhenRelease.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2014 JFrog Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.artifactory.fs.ItemInfo
+import org.artifactory.repo.RepoPath
+import org.artifactory.repo.RepoPathFactory
+import org.jfrog.client.util.PathUtils
+
+import groovy.transform.Field
+
+@Field final String PROPERTIES_FILE_PATH = "plugins/${this.class.name}.properties"
+
+def config = new ConfigSlurper().parse(new File(ctx.artifactoryHome.haAwareEtcDir, PROPERTIES_FILE_PATH).toURI().toURL())
+def repositoriesMSCWR = [:]
+
+log.info "Check 'Maven Snapshot Cleanup When Release' plugin repositories list: $config.repositories"
+
+config.repositories.each{ repositorySettings ->
+    addRepositoriesSettings(repositoriesMSCWR, repositorySettings)
+}
+
+// curl command example for managing configuration of this plugin (prior Artifactory 5.x, use pipe '|' and not semi-colons ';' for parameters separation).
+//
+// curl -i -uadmin:password -X POST "http://localhost:8081/artifactory/api/plugins/execute/mavenSnapshotCleanupWhenReleaseConfig?params=action=reset;repositories=%5B%5B%22maven-local-lib-releases%22%5C%2C%22maven-local-lib-snapshots%22%5D%5C%2C%5B%22maven-local-plugin-releases%22%5C%2C%22maven-local-plugin-snapshots%22%5D%5D"
+//
+executions {
+    mavenSnapshotCleanupWhenReleaseConfig() { params ->
+        log.info "Update configuration with parameters: " + params
+        def action = params['action'] ? params['action'][0] as String : "add"
+        def repositoriesString = params['repositories'] ? params['repositories'][0] as String : "[]"
+        def configRepositories = new ConfigSlurper().parse('repositories=' + repositoriesString)
+
+        if (action == 'reset'){
+            log.info "Reseting configuration before adds"
+            repositoriesMSCWR.clear()
+        }
+
+        configRepositories.repositories.each{repositorySettings -> addRepositoriesSettings(repositoriesMSCWR, repositorySettings) }
+    }
+}
+
+storage {
+
+    // Standard use case, Maven release created in repository
+    afterCreate { ItemInfo item ->
+        removeMavenSnapshotIfRelease(item.getRepoPath(), repositoriesMSCWR)
+    }
+
+    // Promotion usage, Maven release moved from snapshot (but POM is not updated, should be done by another job => experimental)
+    afterMove { ItemInfo item, RepoPath targetRepoPath, properties ->
+        removeMavenSnapshotIfRelease(targetRepoPath, repositoriesMSCWR)
+    }
+
+    // Not used in this case, the pom file should be renamed with SNAPSHOT or timestamp => afterMove use case
+    // afterCopy {}
+
+}
+
+private void addRepositoriesSettings(def repositoriesMSCWR, def repositorySettings){
+    def release = repositorySettings[ 0 ] ? repositorySettings[ 0 ] as String : ["undefined"]
+    def snapshot = repositorySettings[ 1 ] ? repositorySettings[ 1 ] as String : ["undefined"]
+
+    def releaseConfig = repositories.getRepositoryConfiguration(release)
+    def snapshotConfig = repositories.getRepositoryConfiguration(snapshot)
+
+    if (releaseConfig && 'maven' == releaseConfig.getPackageType() && releaseConfig.isHandleReleases() && snapshotConfig && 'maven' == snapshotConfig.getPackageType() && snapshotConfig.isHandleSnapshots()){
+        log.debug "Add repositories couple $release/$snapshot"
+        repositoriesMSCWR[ release ] = snapshot
+    }else{
+        log.error "Skip repositories couple $release/$snapshot (does not exist or incorrect handle policy / package type)"
+    }
+}
+
+private void removeMavenSnapshotIfRelease(RepoPath repoPath, def repositoriesMSCWR){
+    if (repositoriesMSCWR [ repoPath.getRepoKey() ] &&  ! repoPath.isFolder() && repoPath.getPath().endsWith('.pom')){
+        def snapshotRepoPath = RepoPathFactory.create(repositoriesMSCWR [ repoPath.getRepoKey() ], PathUtils.getParent(repoPath.getPath()) + '-SNAPSHOT/')
+        if (repositories.exists(snapshotRepoPath)){
+            if (log.isInfoEnabled()){
+                log.info "Snapshot deletion due to release " + snapshotRepoPath
+            }
+            repositories.delete(snapshotRepoPath)
+        }
+    }
+}

--- a/cleanup/mavenSnapshotCleanupWhenRelease/mavenSnapshotCleanupWhenRelease.properties
+++ b/cleanup/mavenSnapshotCleanupWhenRelease/mavenSnapshotCleanupWhenRelease.properties
@@ -1,0 +1,2 @@
+// List of repositories. In a couple, the first should be the 'release' Maven repository and the second the 'snapshot' Maven repository
+repositories =  [ ["maven-local-lib-releases","maven-local-lib-snapshots"],["maven-local-plugin-releases","maven-local-plugin-snapshots"] ]   


### PR DESCRIPTION
For a Maven repository who handles snapshots, its size can hugly grow up with the time.

[cleanup/artifactCleanup](https://github.com/JFrogDev/artifactory-user-plugins/tree/master/cleanup/artifactCleanup) could be a solution, but a better optimised process could be: **When a component is released, the snapshot should be deleted**.

In addition of deleting completely a snapshot when becomes useless, this process promotes the release version usage.

This PR is a proposal for this feature.