### PR TITLE
Artifactory migration helper user plugin

### DIFF
--- a/migration/artifactoryMigrationHelper/README.md
+++ b/migration/artifactoryMigrationHelper/README.md
@@ -1,0 +1,76 @@
+# Artifactory Migration Helper User Plugin
+
+This plugin automatically sets replication from one Artifactory to another. It was created to help users to migrate to a new Artifactory installation.
+
+## Features
+
+This plugin provides the following features:
+
+- Copy all repositories (local, remote and virtual) from the source Artifactory to the target
+- Set event based push replication for every local repository from the source Artifactory to the target
+
+During the copy repository step, the plugin will ignore everything that has already been added to the target Artifactory. So changes to repositories that have already been handled by this plugin must be done manually at the target Artifactory environment. Besides that, since this plugin copies the virtual repositories in an arbitrary manner, more than one execution may be necessary in order to successfully copy virtual repositories that have other virtual repositories in their compositions.
+
+To minimize concurrent execution of replications, this plugin distribute the replications over time, according to parameters specified by the user in the `artifactoryMigrationHelper.json` configuration file. These parameters are:
+
+- **replicationInitialHour**: left endpoint (inclusive) of the interval in hours where the user wants replications to start.
+    - Possible values: Any integer between [0-23]
+    - Default value: 0
+- **replicationFinalHour**: right endpoint (exclusive) of the interval in hours where the user wants replications to start. 
+    - Possible values: Any integer between [1-24]
+    - Default value: 24
+- **replicationTimes**: Number of times the user wants replication of every repository to start into the given interval. 
+    - Possible values: Any integer bigger or equal to 1
+    - Default value: 1
+- **replicationStep**: Number of minutes between one repository replication start time to another. 
+    - Possible values: Any integer bigger or equal to 1
+    - Default value: 30
+
+The parameters **replicationInitialHour** and **replicationFinalHour** can be used to limit the period of the day where the user wants replications to start. The default configuration file provided will set repository replications to start once a day with a 30 minutes gap between starts for different repositories.
+
+The others parameters present in the configuration file are:
+
+- **cron**: Cron expression to schedule the execution of this plugin.
+    - Possible values: Any valid [cron expression](http://www.quartz-scheduler.org/documentation/quartz-1.x/tutorials/crontrigger)
+    - Default value: Every hour: `0 0 0/1 * * ?`
+- **target**: Target Artifactory url.
+    - Possible values: Url to valid Artifactory installation, including context path
+    - Default value: http://localhost:8081/artifactory
+- **username**: Username to be used to perform REST API calls and setup replication to the target Artifactory. Admin privileges are required.
+    - Possible values: Any valid username with admin privileges
+    - Default value: admin
+- **password**: Password to be used to perform REST API calls and setup replication to the target Artifactory.
+    - Possible values: Any string
+    - Default value: password
+
+## Installation
+
+To install this plugin:
+
+1. Place file `artifactoryMigrationHelper.json` under the master Artifactory server `${ARTIFACTORY_HOME}/etc/plugins`
+2. Edit `artifactoryMigrationHelper.json` file content according to your preferences/environment
+3. Place file `artifactoryMigrationHelper.groovy` under the master Artifactory server `${ARTIFACTORY_HOME}/etc/plugins`
+4. Request [user plugins reload](https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-ReloadPlugins)
+2. Verify in the `${ARTIFACTORY_HOME}/logs/artifactory.log` that the plugin loaded correctly.
+
+### Logging
+
+To enable logging, add the following lines to `$ARTIFACTORY_HOME/etc/logback.xml` file. There is no need to restart Artifactory for this change to take effect:
+
+```xml
+<logger name="artifactoryMigrationHelper">
+    <level value="info"/>
+</logger>
+```
+
+## Usage
+
+### Local CRAN-style repositories
+
+This plugin will run automatically according to the cron expression configured in the configuration file.
+
+To manually request its execution, the following API can be used:
+
+```
+curl -X POST -v -u user:password "http://localhost:8080/artifactory/api/plugins/execute/artifactoryMigrationSetup"`
+```

--- a/migration/artifactoryMigrationHelper/README.md
+++ b/migration/artifactoryMigrationHelper/README.md
@@ -65,8 +65,6 @@ To enable logging, add the following lines to `$ARTIFACTORY_HOME/etc/logback.xml
 
 ## Usage
 
-### Local CRAN-style repositories
-
 This plugin will run automatically according to the cron expression configured in the configuration file.
 
 To manually request its execution, the following API can be used:

--- a/migration/artifactoryMigrationHelper/README.md
+++ b/migration/artifactoryMigrationHelper/README.md
@@ -9,7 +9,7 @@ This plugin provides the following features:
 - Copy all repositories (local, remote and virtual) from the source Artifactory to the target
 - Set event based push replication for every local repository from the source Artifactory to the target
 
-During the copy repository step, the plugin will ignore everything that has already been added to the target Artifactory. So changes to repositories that have already been handled by this plugin must be done manually at the target Artifactory environment. 
+During the copy repository step, the plugin will ignore everything that has already been added to the target Artifactory. So changes to repositories that have already been handled by this plugin must be done manually at the target Artifactory environment.
 
 This plugin copies the virtual repositories in an arbitrary manner, so more than one execution may be necessary in order to successfully copy virtual repositories that have other virtual repositories in their compositions.
 
@@ -18,13 +18,13 @@ To minimize concurrent execution of replications, this plugin distribute the rep
 - **replicationInitialHour**: left endpoint (inclusive) of the interval in hours where the user wants replications to start.
     - Possible values: Any integer between [0-23]
     - Default value: 0
-- **replicationFinalHour**: right endpoint (exclusive) of the interval in hours where the user wants replications to start. 
+- **replicationFinalHour**: right endpoint (exclusive) of the interval in hours where the user wants replications to start.
     - Possible values: Any integer between [1-24]
     - Default value: 24
-- **replicationTimes**: Number of times the user wants replication of every repository to start into the given interval. 
+- **replicationTimes**: Number of times the user wants replication of every repository to start into the given interval.
     - Possible values: Any integer bigger or equal to 1
     - Default value: 1
-- **replicationStep**: Number of minutes between one repository replication start time to another. 
+- **replicationStep**: Number of minutes between one repository replication start time to another.
     - Possible values: Any integer bigger or equal to 1
     - Default value: 30
 
@@ -44,7 +44,7 @@ The others parameters present in the configuration file are:
 - **password**: Password to be used to perform REST API calls and setup replication to the target Artifactory.
     - Possible values: Any string
     - Default value: password
-    
+
 ## Limitations
 
 This user plugin does not handle repository layouts. In order for this plugin to work properly, the user must manually sync the repository layouts between the source and the target Artifactory installations.
@@ -57,7 +57,7 @@ To install this plugin:
 2. Edit `artifactoryMigrationHelper.json` file content according to your preferences/environment
 3. Place file `artifactoryMigrationHelper.groovy` under the master Artifactory server `${ARTIFACTORY_HOME}/etc/plugins`
 4. Request [user plugins reload](https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-ReloadPlugins)
-2. Verify in the `${ARTIFACTORY_HOME}/logs/artifactory.log` that the plugin loaded correctly.
+2. Verify in the system logs that the plugin loaded correctly.
 
 ### Logging
 

--- a/migration/artifactoryMigrationHelper/README.md
+++ b/migration/artifactoryMigrationHelper/README.md
@@ -44,6 +44,10 @@ The others parameters present in the configuration file are:
 - **password**: Password to be used to perform REST API calls and setup replication to the target Artifactory.
     - Possible values: Any string
     - Default value: password
+    
+## Limitations
+
+This user plugin does not handle repository layouts. In order for this plugin to work properly, the user must manually sync the repository layouts between the source and the target Artifactory installations.
 
 ## Installation
 

--- a/migration/artifactoryMigrationHelper/README.md
+++ b/migration/artifactoryMigrationHelper/README.md
@@ -9,7 +9,9 @@ This plugin provides the following features:
 - Copy all repositories (local, remote and virtual) from the source Artifactory to the target
 - Set event based push replication for every local repository from the source Artifactory to the target
 
-During the copy repository step, the plugin will ignore everything that has already been added to the target Artifactory. So changes to repositories that have already been handled by this plugin must be done manually at the target Artifactory environment. Besides that, since this plugin copies the virtual repositories in an arbitrary manner, more than one execution may be necessary in order to successfully copy virtual repositories that have other virtual repositories in their compositions.
+During the copy repository step, the plugin will ignore everything that has already been added to the target Artifactory. So changes to repositories that have already been handled by this plugin must be done manually at the target Artifactory environment. 
+
+This plugin copies the virtual repositories in an arbitrary manner, so more than one execution may be necessary in order to successfully copy virtual repositories that have other virtual repositories in their compositions.
 
 To minimize concurrent execution of replications, this plugin distribute the replications over time, according to parameters specified by the user in the `artifactoryMigrationHelper.json` configuration file. These parameters are:
 

--- a/migration/artifactoryMigrationHelper/artifactoryMigrationHelper.groovy
+++ b/migration/artifactoryMigrationHelper/artifactoryMigrationHelper.groovy
@@ -1,0 +1,297 @@
+import groovy.json.JsonBuilder
+import groovy.json.JsonOutput;
+import groovy.json.JsonSlurper
+import groovy.xml.XmlUtil
+import org.artifactory.addon.replication.AllReplicationRequestHandler
+import org.artifactory.descriptor.replication.LocalReplicationDescriptor
+import org.artifactory.repo.RepoPathFactory
+import groovy.transform.Field
+import javax.xml.bind.JAXBContext
+import org.artifactory.descriptor.config.CentralConfigDescriptorImpl
+import org.artifactory.repo.service.InternalRepositoryService
+import org.artifactory.repo.LocalRepositoryConfigurationImpl
+import org.artifactory.repo.HttpRepositoryConfigurationImpl
+import org.artifactory.repo.VirtualRepositoryConfigurationImpl
+import org.artifactory.descriptor.repo.RepoType
+import org.codehaus.jackson.map.ObjectMapper
+
+@Field def configFileLocation = 'plugins/artifactoryMigrationHelper.json'
+@Field def config = loadConfig()
+
+def loadConfig() {
+    def etcdir = ctx.artifactoryHome.haAwareEtcDir
+    def propsfile = new File(etcdir, configFileLocation)
+    def props = new JsonSlurper().parse(propsfile)
+    def target = props.target
+    if (!target.endsWith('/')) target += '/'
+    return [
+        target: target, username: props.username, password: props.password,
+        replicationTimes: props.replicationTimes,
+        replicationStep: props.replicationStep,
+        replicationInitialHour: props.replicationInitialHour,
+        replicationFinalHour: props.replicationFinalHour
+    ]
+}
+
+def getCron() {
+    def etcdir = ctx.artifactoryHome.haAwareEtcDir
+    def propsfile = new File(etcdir, configFileLocation)
+    def props = new JsonSlurper().parse(propsfile)
+    return props.cron
+}
+
+jobs {
+    artifactoryMigrationSetupJob(cron: getCron()) {
+        try {
+            setupArtifactoryMigration()
+        } catch (Exception e) {
+            log.error("Failed to setup Artifactory migration", e)
+        }
+    }
+}
+
+executions {
+    artifactoryMigrationSetup() {
+        try {
+            setupArtifactoryMigration()
+            message = 'Setup completed successfully'
+            status = 200
+        } catch (Exception e) {
+            log.error("Failed to setup Artifactory migration", e)
+            message = "Failed to setup Artifactory migration: ${e.getMessage()}"
+            status = 500
+        }
+    }
+}
+
+def setupArtifactoryMigration() {
+    log.info "Setting up replication to $config.target"
+    def changesHolder = []
+    def localConfig = getLocalArtifactoryConfig()
+    def remoteRepositories = getRemoteArtifactoryRepositories()
+    log.debug "Remote repositories: $remoteRepositories"
+    handleLocalRepositories(localConfig, remoteRepositories, changesHolder)
+    handleRemoteRepositories(localConfig, remoteRepositories, changesHolder)
+    handleVirtualRepositories(localConfig, remoteRepositories, changesHolder)
+    if (hasChanges(changesHolder)) {
+        log.info "Detected changes on $changesHolder"
+    } else {
+        log.info "No changes detected"
+    }
+    handleReplication(localConfig)
+}
+
+def hasChanges(changesHolder) {
+    log.debug "changesHolder: $changesHolder"
+    return !changesHolder.isEmpty()
+}
+
+def handleLocalRepositories(localConfig, remoteRepositories, changesHolder) {
+    log.info "Handling local repositories"
+    def existingRepositories = remoteRepositories
+        .findAll { it.type == 'LOCAL' }
+        .collect { it.key }
+    log.debug "Existing local repositories: $existingRepositories"
+    def missingRepositories = localConfig.localRepositories.localRepository.findAll {
+        !(it.key in existingRepositories)
+    }
+    if (!missingRepositories.isEmpty()) { changesHolder.push('Local Repositories') }
+    missingRepositories.each {
+        copyLocalRepositoryToRemoteArtifactory(it.key.toString())
+    }
+}
+
+def handleRemoteRepositories(localConfig, remoteRepositories, changesHolder) {
+    log.info "Handling remote repositories"
+    def existingRepositories = remoteRepositories
+        .findAll { it.type == 'REMOTE' }
+        .collect { it.key }
+    log.debug "Existing remote repositories: $existingRepositories"
+    def missingRepositories = localConfig.remoteRepositories.remoteRepository.findAll {
+        !(it.key in existingRepositories)
+    }
+    if (!missingRepositories.isEmpty()) { changesHolder.push('Remote Repositories') }
+    missingRepositories.each {
+        copyRemoteRepositoryToRemoteArtifactory(it.key.toString())
+    }
+}
+
+def handleVirtualRepositories(localConfig, remoteRepositories, changesHolder) {
+    log.info "Handling virtual repositories"
+    def existingRepositories = remoteRepositories
+        .findAll { it.type == 'VIRTUAL' }
+        .collect { it.key }
+    log.debug "Existing virtual repositories: $existingRepositories"
+    def missingRepositories = localConfig.virtualRepositories.virtualRepository.findAll {
+        !(it.key in existingRepositories)
+    }
+    if (!missingRepositories.isEmpty()) { changesHolder.push('Virtual Repositories') }
+    missingRepositories.each {
+        copyVirtualRepositoryToRemoteArtifactory(it.key.toString())
+    }
+}
+
+def handleReplication(localConfig) {
+    log.info "Handling replication configuration"
+    def replicationCronExpOptions = getReplicationCronExpOptions()
+    localConfig.localRepositories.localRepository.each {
+        setupReplication(it.key.toString(), replicationCronExpOptions)
+    }
+}
+
+def setupReplication(repoKey, replicationCronExpOptions) {
+    if (isReplicationConfigurationPending(repoKey)) {
+        // Select a random replication cron exp from the options
+        def selectedCronExp = getRandomArrayValue(replicationCronExpOptions)
+        addReplicationConfiguration(repoKey, selectedCronExp)
+    }
+}
+
+def isReplicationConfigurationPending(repoKey) {
+    def url = config.target + repoKey
+    log.debug "Checking replication configuration for $repoKey -> $url"
+    def descriptor = ctx.centralConfig.descriptor
+    def replication = descriptor.getLocalReplication(repoKey, url)
+    return replication == null
+}
+
+def addReplicationConfiguration(repoKey, cronExp) {
+    log.info "Setting up replication to repo $repoKey with cron expression $cronExp"
+    def replication = new LocalReplicationDescriptor()
+    replication.enabled = true
+    replication.cronExp = cronExp
+    replication.syncDeletes = false
+    replication.syncProperties = true
+    replication.repoKey = repoKey
+    replication.url = config.target + repoKey
+    replication.username = config.username
+    replication.password = config.password
+    replication.enableEventReplication = true
+    def descriptor = ctx.centralConfig.mutableDescriptor
+    descriptor.addLocalReplication(replication)
+    ctx.centralConfig.saveEditedDescriptorAndReload(descriptor)
+}
+
+/*
+* Creates an array with all cron expression options according to the
+* user preferences on the configuration file
+*/
+def getReplicationCronExpOptions() {
+    def times = config.replicationTimes
+    def step = config.replicationStep
+    def initialHour = config.replicationInitialHour
+    def finalHour = config.replicationFinalHour
+
+    def hourStep = (finalHour - initialHour) / times as int
+    def finalFirstExecutionHour = initialHour + hourStep as int
+    def hour = initialHour
+    def minute = 0
+
+    def cronExpOptions = []
+    while (hour < finalFirstExecutionHour) {
+        def hourExpression = "$hour"
+        for (i = 1; i < times; i++) {
+            hourExpression = "$hourExpression,${hour + (hourStep * i)}"
+        }
+        cronExpOptions.push("0 $minute $hourExpression * * ?")
+
+        minute += step
+        while (minute >= 60) {
+            hour++
+            minute -= 60
+        }
+    }
+
+    log.debug "Replication Cron Options: $cronExpOptions"
+    return cronExpOptions
+}
+
+def getLocalArtifactoryConfig() {
+    def artifactoryConfig = ctx.centralConfig.descriptor
+    JAXBContext jc = JAXBContext.newInstance(CentralConfigDescriptorImpl.class)
+    StringWriter sw = new StringWriter()
+    jc.createMarshaller().marshal(artifactoryConfig, sw)
+    return new XmlSlurper(false, false).parseText(sw.toString())
+}
+
+def getRemoteArtifactoryRepositories() {
+    def url = config.target + 'api/repositories'
+    def auth = "Basic ${"$config.username:$config.password".bytes.encodeBase64()}"
+    def conn = null
+    try {
+        conn = new URL(url).openConnection()
+        conn.requestMethod = 'GET'
+        conn.setRequestProperty('Authorization', auth)
+        def responseCode = conn.responseCode
+        if (responseCode == 200) {
+            return new JsonSlurper().parse(new InputStreamReader(conn.inputStream))
+        } else {
+            throw new Exception("Failed to get remote artifactory repositories. HTTP status: $responseCode")
+        }
+    } finally {
+        conn?.disconnect()
+    }
+}
+
+def copyLocalRepositoryToRemoteArtifactory(repoKey) {
+    def repositoryService = ctx.beanForType(InternalRepositoryService.class)
+    def repoDescriptor = repositoryService.localRepoDescriptorByKey(repoKey)
+    def repoConfiguration = new LocalRepositoryConfigurationImpl(repoDescriptor)    
+    createRemoteArtifactoryRepo(repoKey, repoConfiguration)
+}
+
+def copyRemoteRepositoryToRemoteArtifactory(repoKey) {
+    def repositoryService = ctx.beanForType(InternalRepositoryService.class)
+    def repoDescriptor = repositoryService.remoteRepoDescriptorByKey(repoKey)
+    def repoConfiguration = new HttpRepositoryConfigurationImpl(repoDescriptor)
+    createRemoteArtifactoryRepo(repoKey, repoConfiguration)
+}
+
+def copyVirtualRepositoryToRemoteArtifactory(repoKey) {
+    def repositoryService = ctx.beanForType(InternalRepositoryService.class)
+    def repoDescriptor = repositoryService.virtualRepoDescriptorByKey(repoKey)
+    def repoConfiguration = new VirtualRepositoryConfigurationImpl(repoDescriptor)
+    createRemoteArtifactoryRepo(repoKey, repoConfiguration)
+}
+
+def createRemoteArtifactoryRepo(repoKey, repoConfiguration) {
+    log.info "Creating repo $repoKey"
+    def repoConfigurationJson = new ObjectMapper().writeValueAsString(repoConfiguration)
+    log.debug "Repo Configuration: $repoConfigurationJson"
+    repoConfigurationJson = removeNullProperties(repoConfigurationJson)
+    log.debug "Cleaned Repo Configuration: $repoConfigurationJson"
+
+    def url = config.target + "api/repositories/$repoKey"
+    def auth = "Basic ${"$config.username:$config.password".bytes.encodeBase64()}"
+    def conn = null
+    try {
+        conn = new URL(url).openConnection()
+        conn.doOutput = true
+        conn.requestMethod = 'PUT'
+        conn.setRequestProperty('Authorization', auth)
+        conn.setRequestProperty('Content-Type', 'application/json')
+        conn.outputStream.write(repoConfigurationJson.bytes)
+        def responseCode = conn.responseCode
+        if (responseCode != 200) {
+            log.error "Failed to create repository. Message: ${conn.errorStream.text}"
+        }
+    } finally {
+        conn?.disconnect()
+    }
+}
+
+def removeNullProperties(json) {
+    def slurper = new JsonSlurper().parseText(json)
+    for (Iterator<Map.Entry> it = slurper.entrySet().iterator(); it.hasNext();) {
+        Map.Entry entry = it.next();
+        if (entry.getValue() == null) {
+            it.remove()
+        }
+    }
+    return new JsonBuilder(slurper).toPrettyString()
+}
+
+def getRandomArrayValue(array) {
+    def position = Math.random() * array.size() as int
+    return array[position]
+}

--- a/migration/artifactoryMigrationHelper/artifactoryMigrationHelper.json
+++ b/migration/artifactoryMigrationHelper/artifactoryMigrationHelper.json
@@ -1,0 +1,10 @@
+{
+    "cron": "0 0 0/1 * * ?",
+    "target": "http://localhost:8081/artifactory",
+    "username": "admin",
+    "password": "password",
+    "replicationTimes": 1,
+    "replicationStep": 30,
+    "replicationInitialHour": 0,
+    "replicationFinalHour": 24
+}

--- a/migration/artifactoryMigrationHelper/setup.groovy
+++ b/migration/artifactoryMigrationHelper/setup.groovy
@@ -1,0 +1,6 @@
+artifactory 8088, {
+    plugin 'migration/artifactoryMigrationHelper'
+}
+
+artifactory 8081, {
+}

--- a/migration/artifactoryMigrationHelper/test/ArtifactoryMigrationHelperTest.groovy
+++ b/migration/artifactoryMigrationHelper/test/ArtifactoryMigrationHelperTest.groovy
@@ -1,0 +1,173 @@
+import org.jfrog.artifactory.client.ArtifactoryRequest
+import org.jfrog.artifactory.client.impl.ArtifactoryRequestImpl
+import org.jfrog.artifactory.client.model.PackageType
+import org.jfrog.artifactory.client.model.repository.settings.impl.DockerRepositorySettingsImpl
+import org.jfrog.artifactory.client.model.repository.settings.impl.MavenRepositorySettingsImpl
+import org.jfrog.artifactory.client.model.repository.settings.impl.YumRepositorySettingsImpl
+import spock.lang.Specification
+import spock.lang.Shared
+
+import static org.jfrog.artifactory.client.ArtifactoryClient.create
+
+class ArtifactoryMigrationHelperTest extends Specification {
+    public static final String MAVEN_LOCAL_KEY = 'libs-release-local'
+    public static final String MAVEN_REMOTE_KEY = 'jcenter'
+    public static final String MAVEN_VIRTUAL_KEY = 'libs-release'
+    public static final String DOCKER_LOCAL_KEY = 'docker-local'
+    public static final String RPM_LOCAL_KEY = 'rpm-local'
+
+    static final sourceBaseurl = 'http://localhost:8088/artifactory'
+    @Shared sourceArtifactory = create(sourceBaseurl, 'admin', 'password')
+
+    static final targetBaseurl = 'http://localhost:8081/artifactory'
+    @Shared targetArtifactory = create(targetBaseurl, 'admin', 'password')
+
+    def 'maven repo migration test'() {
+        setup:
+        // Create maven local repo
+        def mavenLocal = createLocalRepo(sourceArtifactory, MAVEN_LOCAL_KEY, new MavenRepositorySettingsImpl())
+        // Create maven remote repo
+        def mavenRemote = createRemoteRepo(sourceArtifactory, MAVEN_REMOTE_KEY, new MavenRepositorySettingsImpl(), 'https://jcenter.bintray.com')
+        // Create maven virtual repo
+        def mavenVirtual = createVirtualRepo(sourceArtifactory, MAVEN_VIRTUAL_KEY, new MavenRepositorySettingsImpl(), [MAVEN_LOCAL_KEY, MAVEN_REMOTE_KEY])
+
+
+        // Execute plugin
+        when:
+        def message = sourceArtifactory.plugins().execute('artifactoryMigrationSetup').sync()
+        then:
+        message == 'Setup completed successfully'
+
+        // Validate maven repos were created at target
+        when:
+        def targetMavenLocal = getRepo(targetArtifactory, MAVEN_LOCAL_KEY)
+        def targetMavenRemote = getRepo(targetArtifactory, MAVEN_REMOTE_KEY)
+        def targetMavenVirtual = getRepo(targetArtifactory, MAVEN_VIRTUAL_KEY)
+        then:
+        targetMavenLocal != null
+        targetMavenLocal.repositorySettings.packageType == PackageType.maven
+        targetMavenRemote != null
+        targetMavenVirtual != null
+
+        // Check local maven repo replication was set
+        when:
+        def mavenLocalReplications = getRepoReplication(sourceArtifactory, MAVEN_LOCAL_KEY)
+        then:
+        mavenLocalReplications.size() == 1
+        mavenLocalReplications[0].url.endsWith("artifactory/$MAVEN_LOCAL_KEY")
+
+        cleanup:
+        // Remove repos
+        deleteRepo(sourceArtifactory, MAVEN_LOCAL_KEY)
+        deleteRepo(sourceArtifactory, MAVEN_REMOTE_KEY)
+        deleteRepo(sourceArtifactory, MAVEN_VIRTUAL_KEY)
+
+        deleteRepo(targetArtifactory, MAVEN_LOCAL_KEY)
+        deleteRepo(targetArtifactory, MAVEN_REMOTE_KEY)
+        deleteRepo(targetArtifactory, MAVEN_VIRTUAL_KEY)
+    }
+
+    def 'docker repo migration test'() {
+        setup:
+        // Create docker local repo
+        def dockerLocal = createLocalRepo(sourceArtifactory, DOCKER_LOCAL_KEY, new DockerRepositorySettingsImpl())
+
+        // Execute plugin
+        when:
+        def message = sourceArtifactory.plugins().execute('artifactoryMigrationSetup').sync()
+        then:
+        message == 'Setup completed successfully'
+
+        // Check docker repo was created at target
+        when:
+        def targetDockerLocal = getRepo(targetArtifactory, DOCKER_LOCAL_KEY)
+        then:
+        targetDockerLocal != null
+        targetDockerLocal.repositorySettings.packageType == PackageType.docker
+
+        // Check docker repo replication was set
+        when:
+        def dockerLocalReplications = getRepoReplication(sourceArtifactory, DOCKER_LOCAL_KEY)
+        then:
+        dockerLocalReplications.size() == 1
+        dockerLocalReplications[0].url.endsWith("artifactory/$DOCKER_LOCAL_KEY")
+
+        cleanup:
+        // Remove repos
+        deleteRepo(sourceArtifactory, DOCKER_LOCAL_KEY)
+        deleteRepo(targetArtifactory, DOCKER_LOCAL_KEY)
+    }
+
+    def 'rpm repo migration test'() {
+        setup:
+        // Create rpm package
+        def rpmLocal = createLocalRepo(sourceArtifactory, RPM_LOCAL_KEY, new YumRepositorySettingsImpl())
+
+        // Execute plugin
+        when:
+        def message = sourceArtifactory.plugins().execute('artifactoryMigrationSetup').sync()
+        then:
+        message == 'Setup completed successfully'
+
+        // Check rpm repo was created at target
+        when:
+        def targetRpmLocal = getRepo(targetArtifactory, RPM_LOCAL_KEY)
+        then:
+        targetRpmLocal != null
+
+        // Check rpm repo replication was set
+        when:
+        def rpmLocalReplications = getRepoReplication(sourceArtifactory, RPM_LOCAL_KEY)
+        then:
+        rpmLocalReplications.size() == 1
+        rpmLocalReplications[0].url.endsWith("artifactory/$RPM_LOCAL_KEY")
+
+        cleanup:
+        // Remove repos
+        deleteRepo(sourceArtifactory, RPM_LOCAL_KEY)
+        deleteRepo(targetArtifactory, RPM_LOCAL_KEY)
+    }
+
+    def createLocalRepo(artifactory, repoKey, repositorySettings) {
+        def builder = artifactory.repositories().builders()
+        def repo = builder.localRepositoryBuilder().key(repoKey)
+                .repositorySettings(repositorySettings)
+                .build()
+        artifactory.repositories().create(0, repo)
+    }
+
+    def createRemoteRepo(artifactory, repoKey, repositorySettings, url) {
+        def builder = artifactory.repositories().builders()
+        def repo = builder.remoteRepositoryBuilder().key(repoKey)
+                .repositorySettings(repositorySettings)
+                .url(url)
+                .build()
+        artifactory.repositories().create(0, repo)
+    }
+
+    def createVirtualRepo(artifactory, repoKey, repositorySettings, includedRepositories) {
+        def builder = artifactory.repositories().builders()
+        def repo = builder.virtualRepositoryBuilder().key(repoKey)
+                .repositorySettings(repositorySettings)
+                .repositories(includedRepositories)
+                .build()
+        artifactory.repositories().create(0, repo)
+    }
+
+    def deleteRepo(artifactory, key) {
+        def repo = artifactory.repository(key)
+        repo?.delete()
+    }
+
+    def getRepo(artifactory, key) {
+        return artifactory.repository(key).get()
+    }
+
+    def getRepoReplication(artifactory, key) {
+        ArtifactoryRequest getReplications = new ArtifactoryRequestImpl()
+            .apiUrl("api/replications/$key")
+            .method(ArtifactoryRequest.Method.GET)
+            .responseType(ArtifactoryRequest.ContentType.JSON)
+        return artifactory.restCall(getReplications)
+    }
+}


### PR DESCRIPTION
This plugin automatically sets replication from one Artifactory to another. It was created to help users to migrate to a new Artifactory installation.