### PR TITLE
fix: update pom to include valid repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <!-- Properties to update depending your current development (ex: 'cleanup/artifactCleanup') and the local Artifactory endpoint -->
     <user.plugin.dev>dummyPlugin</user.plugin.dev>
     <artifactory.home.location>${env.ARTIFACTORY_HOME}</artifactory.home.location>
-    <version.artifactory>5.4.4</version.artifactory>
+    <version.artifactory>7.37.14</version.artifactory>
 
     <!-- Common properties -->
     <sonar.exclusions>**/*.java,**/*Test.groovy,**/*test.groovy</sonar.exclusions>
@@ -54,8 +54,35 @@
   </build>
   <repositories>
     <repository>
-      <id>jcenter</id>
-      <url>https://jcenter.bintray.com</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>central-jfrog</id>
+      <name>oss-releases</name>
+      <url>https://releases-docker.jfrog.io/artifactory/oss-releases-local</url>
+    </repository>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>jars-jfrog</id>
+      <name>jfrog-jars</name>
+      <url>https://releases-docker.jfrog.io/artifactory/jfrog-jars/</url>
+    </repository>
+    <repository>
+      <snapshots />
+      <id>snapshots</id>
+      <name>oss-snapshots</name>
+      <url>https://releases-docker.jfrog.io/artifactory/oss-snapshots</url>
+    </repository>
+    <repository>
+      <id>central</id>
+      <name>Maven Central</name>
+      <layout>default</layout>
+      <url>https://repo1.maven.org/maven2</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </repository>
   </repositories>
   <dependencies>
@@ -78,7 +105,7 @@
     <dependency>
       <groupId>org.jfrog.artifactory.client</groupId>
       <artifactId>artifactory-java-client-services</artifactId>
-      <version>2.5.1</version>
+      <version>2.12.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
The current upstream pom.xml includes the old JCenter Repo and does not work anymore.

Please check my MR, not sure if these are the proper repositories.