### PR TITLE
Fix NPE for remoteBackup

### DIFF
--- a/storage/remoteBackup/remoteBackup.groovy
+++ b/storage/remoteBackup/remoteBackup.groovy
@@ -35,7 +35,12 @@ jobs {
 
 executions {
   remoteBackup() { params ->
-    def repos = params?.getAt('repos') ?: null
+    def repos
+    if (params == null || params.isEmpty()) {
+        repos = []
+    } else {
+        repos = params?.getAt('repos') ?: []
+    }
     def (complete, total) = runBackup(repos)
     if (complete instanceof CharSequence) {
       message = "Error copying items: $complete"


### PR DESCRIPTION
This behavior is caused by a Groovy 4 compatibility change introduced through stricter type handling during assignment and parameter processing. Added additional checks to avoid NPE