### PR TITLE
feat(cleanDockerImages): Add `globalMaxDays` and `globalMaxCount`

### DIFF
--- a/cleanup/cleanDockerImages/README.md
+++ b/cleanup/cleanDockerImages/README.md
@@ -11,43 +11,71 @@ The `cleanDockerImages.properties` file has the following fields:
 
 - `dockerRepos`: A list of Docker repositories to clean. If a repo is not in
   this list, it will not be cleaned.
-- `byDownloadDate`: An optional boolean flag (true/false). 
+- `byDownloadDate`: An optional boolean flag (true/false).
     * **false** (default): retention will take into account only **creation** date of the image
       (technically, its manifest file). This is the original behaviour.
     * **true**: identify images to remove by their **last download date** or failing that,
       last **update** date. This mode of operation has been inspired by the 'artifactCleanup'
       plugin.
+- `globalMaxDays`: An optional global fallback value (integer) for `maxDays` retention policy.
+  This value will be applied to all Docker images that don't have an explicit
+  `com.jfrog.artifactory.retention.maxDays` label. Set to `null` or omit to disable global `maxDays` policy.
+- `globalMaxCount`: An optional global fallback value (integer) for `maxCount` retention policy.
+  This value will be applied to all Docker images that don't have an explicit
+  `com.jfrog.artifactory.retention.maxCount` label. Set to `null` or omit to disable global `maxCount` policy.
 
 For example:
 
-``` json
+``` groovy
 dockerRepos = ["example-docker-local", "example-docker-local-2"]
 byDownloadDate = false
+globalMaxDays = 30
+globalMaxCount = 5
 ```
+
+This configuration will clean Docker images from the two specified repositories, using creation date
+for retention checks. Images without explicit labels will be deleted if they are older than 30 days
+or if there are more than 5 versions of the same image.
 
 Usage
 -----
 
-Cleanup policies are specified as labels on the Docker image. Currently, this
-plugin supports the following policies:
+Cleanup policies can be specified in two ways:
 
-- `maxDays`: The maximum number of days a Docker image can exist in an
-  Artifactory repository. Any images older than this will be deleted.
-    * when `byDownloadDate=true`: images downloaded or updated within last `maxDays` will
-      be preserved
-- `maxCount`: The maximum number of versions of a particular image which should
-  exist. For example, if there are 10 versions of a Docker image and `maxCount`
-  is set to 6, the oldest 4 versions of the image will be deleted.
-    * when `byDownloadDate=true`: image age will be determined by first checking
-     the _Last Downloaded Date_ and _Modification Date_ will be checked only when this image has never
-     been downloaded.
+### 1. Image-Specific Labels (Priority)
 
-To set these labels for an image, add them to the Dockerfile before building:
+Labels on individual Docker images take priority over global settings. Add them to the Dockerfile before building:
 
 ``` dockerfile
 LABEL com.jfrog.artifactory.retention.maxCount="10"
 LABEL com.jfrog.artifactory.retention.maxDays="7"
 ```
+
+### 2. Global Fallback Values
+
+For images without explicit labels, the plugin will use the global values configured in
+`cleanDockerImages.properties` (see Configuration section above).
+
+### Retention Policies
+
+Currently, this plugin supports the following policies:
+
+- `maxDays`: The maximum number of days a Docker image can exist in an
+  Artifactory repository. Any images older than this will be deleted.
+    * when `byDownloadDate=false` (default): images created within last `maxDays` will be preserved
+    * when `byDownloadDate=true`: images downloaded or updated within last `maxDays` will
+      be preserved
+- `maxCount`: The maximum number of versions of a particular image which should
+  exist. For example, if there are 10 versions of a Docker image and `maxCount`
+  is set to 6, the oldest 4 versions of the image will be deleted.
+    * when `byDownloadDate=false` (default): image age determined by creation date
+    * when `byDownloadDate=true`: image age will be determined by first checking
+     the _Last Downloaded Date_ and _Modification Date_ will be checked only when this image has never
+     been downloaded.
+
+**Note:** Image-specific labels always take precedence over global fallback values.
+
+### Execution
 
 When a Docker image is deployed, Artifactory will automatically create
 properties reflecting each of its labels. These properties are read by the

--- a/cleanup/cleanDockerImages/cleanDockerImages.groovy
+++ b/cleanup/cleanDockerImages/cleanDockerImages.groovy
@@ -26,7 +26,7 @@ executions {
     cleanDockerImages() { params ->
         def deleted = []
         def etcdir = ctx.artifactoryHome.etcDir
-        def propsfile = new File(etcdir, "plugins/cleanDockerImages.properties")
+        def propsfile = new File(etcdir, 'plugins/cleanDockerImages.properties')
         def propConfigData = new ConfigSlurper().parse(propsfile.toURL())
         def repos = propConfigData.dockerRepos
         def dryRun = params['dryRun'] ? params['dryRun'][0] as boolean : false
@@ -35,10 +35,14 @@ executions {
         def byDownloadDate = propConfigData.byDownloadDate ? propConfigData.byDownloadDate : false
         byDownloadDate = params['byDownloadDate'] ? params['byDownloadDate'][0] as boolean : byDownloadDate
 
-        log.info("cleanDockerImages: Options dryRun=${dryRun}, byDownloadDate=${byDownloadDate}")
+        // Load global retention settings as fallback values
+        def globalMaxDays = propConfigData.globalMaxDays ? propConfigData.globalMaxDays as Integer : null
+        def globalMaxCount = propConfigData.globalMaxCount ? propConfigData.globalMaxCount as Integer : null
+
+        log.info("cleanDockerImages: Options dryRun=${dryRun}, byDownloadDate=${byDownloadDate}, globalMaxDays=${globalMaxDays}, globalMaxCount=${globalMaxCount}")
         repos.each {
             log.debug("Cleaning Docker images in repo: $it")
-            def del = buildParentRepoPaths(RepoPathFactory.create(it), dryRun, byDownloadDate)
+            def del = this.buildParentRepoPaths(RepoPathFactory.create(it), dryRun, byDownloadDate, globalMaxDays, globalMaxCount)
             deleted.addAll(del)
         }
         def json = [status: 'okay', dryRun: dryRun, deleted: deleted]
@@ -47,10 +51,10 @@ executions {
     }
 }
 
-def buildParentRepoPaths(path, dryRun, byDownloadDate) {
+def buildParentRepoPaths(path, dryRun, byDownloadDate, globalMaxDays, globalMaxCount) {
     def deleted = [], oldSet = [], imagesPathMap = [:], imagesCount = [:]
     def parentInfo = repositories.getItemInfo(path)
-    simpleTraverse(parentInfo, oldSet, imagesPathMap, imagesCount, byDownloadDate)
+    simpleTraverse(parentInfo, oldSet, imagesPathMap, imagesCount, byDownloadDate, globalMaxDays, globalMaxCount)
     for (img in oldSet) {
         deleted << img.id
         if (!dryRun) repositories.delete(img)
@@ -74,27 +78,27 @@ def buildParentRepoPaths(path, dryRun, byDownloadDate) {
 // - delete the images immediately if the maxDays policy applies
 // - Aggregate the images that qualify for maxCount policy (to get deleted in
 //   the execution closure)
-def simpleTraverse(parentInfo, oldSet, imagesPathMap, imagesCount, byDownloadDate) {
+def simpleTraverse(parentInfo, oldSet, imagesPathMap, imagesCount, byDownloadDate, globalMaxDays, globalMaxCount) {
     def maxCount = null
     def parentRepoPath = parentInfo.repoPath
     for (childItem in repositories.getChildren(parentRepoPath)) {
         def currentPath = childItem.repoPath
         if (childItem.isFolder()) {
-            simpleTraverse(childItem, oldSet, imagesPathMap, imagesCount, byDownloadDate)
+            simpleTraverse(childItem, oldSet, imagesPathMap, imagesCount, byDownloadDate, globalMaxDays, globalMaxCount)
             continue
         }
         log.debug("Scanning File: $currentPath.name")
-        if (currentPath.name != "manifest.json") continue
+        if (currentPath.name != 'manifest.json') continue
         // get the properties here and delete based on policies:
         // - implement daysPassed policy first and delete the images that
         //   qualify
         // - aggregate the image info to group by image and sort by create
         //   (byDownloadDate=false) or downloaded/updated (byDownloadDate=true)
         //   date for maxCount policy
-        if (checkDaysPassedForDelete(childItem, byDownloadDate)) {
+        if (checkDaysPassedForDelete(childItem, byDownloadDate, globalMaxDays)) {
             log.debug("Adding to OLD MAP: $parentRepoPath")
             oldSet << parentRepoPath
-        } else if ((maxCount = getMaxCountForDelete(childItem)) > 0) {
+        } else if ((maxCount = getMaxCountForDelete(childItem, globalMaxCount)) > 0) {
             log.debug("Adding to IMAGES MAP: $parentRepoPath")
             def parentId = parentRepoPath.parent.id
             def oldmax = maxCount
@@ -133,8 +137,8 @@ def getItemLastUsedDate(item, byDownloadDate) {
     def itemLastUse = item.created
 
     if (byDownloadDate) {
-      lastDownloadedDate = getLastDownloadedDate(item.repoPath)
-      itemLastUse = (lastDownloadedDate) ? lastDownloadedDate : item.getLastUpdated()
+        lastDownloadedDate = getLastDownloadedDate(item.repoPath)
+        itemLastUse = (lastDownloadedDate) ? lastDownloadedDate : item.getLastUpdated()
     }
 
     log.debug("itemLastUse = ${itemLastUse} item.created = ${item.created} item.getLastUpdated = ${item.getLastUpdated()}")
@@ -143,14 +147,25 @@ def getItemLastUsedDate(item, byDownloadDate) {
 
 // This method checks if the docker image's manifest has the property
 // "com.jfrog.artifactory.retention.maxDays" for purge
-def checkDaysPassedForDelete(item, byDownloadDate) {
-    def maxDaysProp = "docker.label.com.jfrog.artifactory.retention.maxDays"
+// Falls back to globalMaxDays if the property is not set on the item
+def checkDaysPassedForDelete(item, byDownloadDate, globalMaxDays) {
+    def maxDaysProp = 'docker.label.com.jfrog.artifactory.retention.maxDays'
     def oneday = TimeUnit.MILLISECONDS.convert(1, TimeUnit.DAYS)
     def prop = repositories.getProperty(item.repoPath, maxDaysProp)
-    if (!prop) return false
 
-    log.debug("PROPERTY maxDays FOUND = $prop IN MANIFEST FILE ${item.repoPath}")
-    prop = prop.isInteger() ? prop.toInteger() : null
+    // Use item-specific property if available, otherwise fall back to global setting
+    if (!prop && globalMaxDays != null) {
+        prop = globalMaxDays
+        log.debug("Using global maxDays = $prop for ${item.repoPath}")
+    } else if (!prop) {
+        return false
+    } else {
+        log.debug("PROPERTY maxDays FOUND = $prop IN MANIFEST FILE ${item.repoPath}")
+        if (prop instanceof String) {
+            prop = prop.isInteger() ? prop.toInteger() : null
+        }
+    }
+
     if (prop == null) return false
 
     def fileLastUseDate = getItemLastUsedDate(item, byDownloadDate)
@@ -159,12 +174,23 @@ def checkDaysPassedForDelete(item, byDownloadDate) {
 
 // This method checks if the docker image's manifest has the property
 // "com.jfrog.artifactory.retention.maxCount" for purge
-def getMaxCountForDelete(item) {
-    def maxCountProp = "docker.label.com.jfrog.artifactory.retention.maxCount"
+// Falls back to globalMaxCount if the property is not set on the item
+def getMaxCountForDelete(item, globalMaxCount) {
+    def maxCountProp = 'docker.label.com.jfrog.artifactory.retention.maxCount'
     def prop = repositories.getProperty(item.repoPath, maxCountProp)
-    if (!prop) return 0
 
-    log.debug("PROPERTY maxCount FOUND = $prop IN MANIFEST FILE ${item}")
-    prop = prop.isInteger() ? prop.toInteger() : 0
+    // Use item-specific property if available, otherwise fall back to global setting
+    if (!prop && globalMaxCount != null) {
+        prop = globalMaxCount
+        log.debug("Using global maxCount = $prop for ${item.repoPath}")
+    } else if (!prop) {
+        return 0
+    } else {
+        log.debug("PROPERTY maxCount FOUND = $prop IN MANIFEST FILE ${item}")
+        if (prop instanceof String) {
+            prop = prop.isInteger() ? prop.toInteger() : 0
+        }
+    }
+
     return prop > 0 ? prop : 0
 }

--- a/cleanup/cleanDockerImages/cleanDockerImages.properties
+++ b/cleanup/cleanDockerImages/cleanDockerImages.properties
@@ -1,2 +1,4 @@
 dockerRepos = ["example-docker-local"]
 byDownloadDate = false
+globalMaxDays = null
+globalMaxCount = null


### PR DESCRIPTION
## Add Global Retention Policy Fallbacks for cleanDockerImages Plugin

### Overview

This PR extends the `cleanDockerImages` plugin to support optional global fallback values for retention policies, eliminating the need to manually label every Docker image with retention policies.

### Motivation

Previously, each Docker image had to be explicitly labeled with `com.jfrog.artifactory.retention.maxDays` and/or `com.jfrog.artifactory.retention.maxCount` in its Dockerfile. This approach had limitations:

- Requires rebuilding images to change retention policies
- Not practical for third-party images that can't be modified
- Tedious to manage retention across many images
- No way to set repository-wide defaults

### Changes

#### New Configuration Options

Added two optional configuration parameters to `cleanDockerImages.properties`:

- **`globalMaxDays`**: Global fallback for maximum age retention (in days)
- **`globalMaxCount`**: Global fallback for maximum version count retention

These values apply to images that don't have explicit labels set. Set to `null` or omit to disable.

#### Implementation Details

- Global settings are loaded from the properties file on plugin execution
- Image-specific labels always take precedence over global settings
- Both `maxDays` and `maxCount` policies work with global fallbacks
- Compatible with existing `byDownloadDate` behavior

#### Code Changes

- Modified `checkDaysPassedForDelete()` and `getMaxCountForDelete()` to accept and use global fallback parameters
- Updated function signatures throughout the call chain to pass global settings
- Added type checking to handle both String (from labels) and Integer (from global config) property values
- Enhanced logging to indicate when global values are being used

### Backward Compatibility

**This change is fully backward compatible:**

- Existing configurations without global settings continue to work unchanged
- Image-specific labels are still supported and take priority
- No breaking changes to the plugin API or execution parameters

### Usage Example

```groovy
# cleanDockerImages.properties
dockerRepos = ["docker-local", "docker-prod"]
byDownloadDate = false
globalMaxDays = 30
globalMaxCount = 5
```